### PR TITLE
fix: force return type for usort callback

### DIFF
--- a/src/Modules/Rollback.php
+++ b/src/Modules/Rollback.php
@@ -340,10 +340,10 @@ class Rollback extends Abstract_Module {
 	 * @param mixed $a First version to compare.
 	 * @param mixed $b Second version to compare.
 	 *
-	 * @return bool Which version is greater?
+	 * @return int Which version is greater?
 	 */
 	public function sort_rollback_array( $a, $b ) {
-		return version_compare( $b['version'], $a['version'] );
+		return (int) version_compare( $b['version'], $a['version'] );
 	}
 
 	/**


### PR DESCRIPTION
This looks like a weird issue as `version_compare` should return `int` if no `operator` is passed.
I've forced the return type to `int` so that `usort` will not throw a deprecated error.

References: Codeinwp/themeisle-sdk#102 Codeinwp/optimole-wp#359