### PR TITLE
Fix php8.1 problem

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           php-version: '7.1'
           extensions: simplexml, mysql
-          tools: phpunit:7.5.9
+          tools: phpunit-polyfills
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Install WordPress Test Suite

--- a/load.php
+++ b/load.php
@@ -31,12 +31,12 @@ if ( ! is_file( $themeisle_sdk_path . $themeisle_sdk_relative_licenser_path ) &&
 
 if ( ( is_null( $themeisle_sdk_max_path ) || version_compare( $themeisle_sdk_version, $themeisle_sdk_max_path ) == 0 ) &&
 	apply_filters( 'themeisle_sdk_should_overwrite_path', false, $themeisle_sdk_path, $themeisle_sdk_max_path ) ) {
-    $themeisle_sdk_max_path = $themeisle_sdk_path;
+	$themeisle_sdk_max_path = $themeisle_sdk_path;
 }
 
 if ( is_null( $themeisle_sdk_max_version ) || version_compare( $themeisle_sdk_version, $themeisle_sdk_max_version ) > 0 ) {
-    $themeisle_sdk_max_version = $themeisle_sdk_version;
-    $themeisle_sdk_max_path    = $themeisle_sdk_path;
+	$themeisle_sdk_max_version = $themeisle_sdk_version;
+	$themeisle_sdk_max_path    = $themeisle_sdk_path;
 }
 
 // load the latest sdk version from the active Themeisle products.

--- a/load.php
+++ b/load.php
@@ -28,14 +28,15 @@ if ( ! is_file( $themeisle_sdk_path . $themeisle_sdk_relative_licenser_path ) &&
 	$themeisle_sdk_abs_licenser_path = $themeisle_sdk_max_path . $themeisle_sdk_relative_licenser_path;
 	add_filter( 'themeisle_sdk_required_files', 'themeisle_sdk_load_licenser_if_present' );
 }
-if ( version_compare( $themeisle_sdk_version, $themeisle_sdk_max_path ) == 0 &&
-	apply_filters( 'themeisle_sdk_should_overwrite_path', false, $themeisle_sdk_path, $themeisle_sdk_max_path ) ) {
-	$themeisle_sdk_max_path = $themeisle_sdk_path;
+
+if ( ( is_null( $themeisle_sdk_max_path ) || version_compare( $themeisle_sdk_version, $themeisle_sdk_max_path ) == 0 ) &&
+    apply_filters( 'themeisle_sdk_should_overwrite_path', false, $themeisle_sdk_path, $themeisle_sdk_max_path ) ) {
+    $themeisle_sdk_max_path = $themeisle_sdk_path;
 }
 
-if ( version_compare( $themeisle_sdk_version, $themeisle_sdk_max_version ) > 0 ) {
-	$themeisle_sdk_max_version = $themeisle_sdk_version;
-	$themeisle_sdk_max_path    = $themeisle_sdk_path;
+if ( is_null( $themeisle_sdk_max_version ) || version_compare( $themeisle_sdk_version, $themeisle_sdk_max_version ) > 0 ) {
+    $themeisle_sdk_max_version = $themeisle_sdk_version;
+    $themeisle_sdk_max_path    = $themeisle_sdk_path;
 }
 
 // load the latest sdk version from the active Themeisle products.

--- a/load.php
+++ b/load.php
@@ -30,7 +30,7 @@ if ( ! is_file( $themeisle_sdk_path . $themeisle_sdk_relative_licenser_path ) &&
 }
 
 if ( ( is_null( $themeisle_sdk_max_path ) || version_compare( $themeisle_sdk_version, $themeisle_sdk_max_path ) == 0 ) &&
-    apply_filters( 'themeisle_sdk_should_overwrite_path', false, $themeisle_sdk_path, $themeisle_sdk_max_path ) ) {
+	apply_filters( 'themeisle_sdk_should_overwrite_path', false, $themeisle_sdk_path, $themeisle_sdk_max_path ) ) {
     $themeisle_sdk_max_path = $themeisle_sdk_path;
 }
 


### PR DESCRIPTION
 version_compare(): passing null to parameter 2

Reference: Codeinwp/wp-menu-icons#197, https://github.com/Codeinwp/themeisle-sdk/issues/109