### PR TITLE
fix: check if transient exists in DB [Codeinwp/hestia-pro#2400]

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           php-version: '7.1'
           extensions: simplexml, mysql
-          tools: phpunit:7.5.9
+          tools: phpunit-polyfills
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Install WordPress Test Suite

--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -876,11 +876,11 @@ class Licenser extends Abstract_Module {
 		}
 		if ( $this->product->is_theme() ) {
 			add_filter( 'site_transient_update_themes', array( &$this, 'theme_update_transient' ) );
-//			add_action( 'delete_site_transient_update_themes', array( &$this, 'delete_theme_update_transient' ) );
-//			add_action( 'load-update-core.php', array( &$this, 'delete_theme_update_transient' ) );
-//			add_action( 'load-themes.php', array( &$this, 'delete_theme_update_transient' ) );
-//			add_action( 'load-themes.php', array( &$this, 'load_themes_screen' ) );
-//			add_filter( 'http_request_args', array( $this, 'disable_wporg_update' ), 5, 2 ); //phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
+			add_action( 'delete_site_transient_update_themes', array( &$this, 'delete_theme_update_transient' ) );
+			add_action( 'load-update-core.php', array( &$this, 'delete_theme_update_transient' ) );
+			add_action( 'load-themes.php', array( &$this, 'delete_theme_update_transient' ) );
+			add_action( 'load-themes.php', array( &$this, 'load_themes_screen' ) );
+			add_filter( 'http_request_args', array( $this, 'disable_wporg_update' ), 5, 2 ); //phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
 
 			return $this;
 

--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -633,7 +633,7 @@ class Licenser extends Abstract_Module {
 	 */
 	public function theme_update_transient( $value ) {
 		$update_data = $this->check_for_update();
-		if ( $update_data ) {
+		if ( ! empty( $value ) && $update_data ) {
 			$value->response[ $this->product->get_slug() ] = $update_data;
 		}
 
@@ -876,11 +876,11 @@ class Licenser extends Abstract_Module {
 		}
 		if ( $this->product->is_theme() ) {
 			add_filter( 'site_transient_update_themes', array( &$this, 'theme_update_transient' ) );
-			add_action( 'delete_site_transient_update_themes', array( &$this, 'delete_theme_update_transient' ) );
-			add_action( 'load-update-core.php', array( &$this, 'delete_theme_update_transient' ) );
-			add_action( 'load-themes.php', array( &$this, 'delete_theme_update_transient' ) );
-			add_action( 'load-themes.php', array( &$this, 'load_themes_screen' ) );
-			add_filter( 'http_request_args', array( $this, 'disable_wporg_update' ), 5, 2 ); //phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
+//			add_action( 'delete_site_transient_update_themes', array( &$this, 'delete_theme_update_transient' ) );
+//			add_action( 'load-update-core.php', array( &$this, 'delete_theme_update_transient' ) );
+//			add_action( 'load-themes.php', array( &$this, 'delete_theme_update_transient' ) );
+//			add_action( 'load-themes.php', array( &$this, 'load_themes_screen' ) );
+//			add_filter( 'http_request_args', array( $this, 'disable_wporg_update' ), 5, 2 ); //phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
 
 			return $this;
 

--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -633,10 +633,19 @@ class Licenser extends Abstract_Module {
 	 */
 	public function theme_update_transient( $value ) {
 		$update_data = $this->check_for_update();
-		if ( ! empty( $value ) && property_exists( $value, 'response' ) && $update_data ) {
-			$value->response[ $this->product->get_slug() ] = $update_data;
-		}
+        if ( empty( $value ) ) {
+            return $value;
+        }
 
+        if ( ! property_exists( $value, 'response' ) ) {
+            return $value;
+        }
+
+        if ( ! $update_data ) {
+            return $value;
+        }
+
+        $value->response[ $this->product->get_slug() ] = $update_data;
 		return $value;
 	}
 

--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -633,19 +633,19 @@ class Licenser extends Abstract_Module {
 	 */
 	public function theme_update_transient( $value ) {
 		$update_data = $this->check_for_update();
-        if ( empty( $value ) ) {
-            return $value;
-        }
+		if ( empty( $value ) ) {
+			return $value;
+		}
 
-        if ( ! property_exists( $value, 'response' ) ) {
-            return $value;
-        }
+		if ( ! property_exists( $value, 'response' ) ) {
+			return $value;
+		}
 
-        if ( ! $update_data ) {
-            return $value;
-        }
+		if ( ! $update_data ) {
+			return $value;
+		}
 
-        $value->response[ $this->product->get_slug() ] = $update_data;
+		$value->response[ $this->product->get_slug() ] = $update_data;
 		return $value;
 	}
 

--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -633,7 +633,7 @@ class Licenser extends Abstract_Module {
 	 */
 	public function theme_update_transient( $value ) {
 		$update_data = $this->check_for_update();
-		if ( ! empty( $value ) && $update_data ) {
+		if ( ! empty( $value ) && property_exists( $value, 'response' ) && $update_data ) {
 			$value->response[ $this->product->get_slug() ] = $update_data;
 		}
 


### PR DESCRIPTION
It seems like in some cases the argument of `theme_update_transient` function is false. This may happen if you delete all transients from DB and have PHP >= 8.0.x or in my case I've just changed the PHP version to 8.0 and I encounter this issue.
In this PR I just make sure the `$value` is not empty and check if the property exists.

It should fix [Codeinwp/hestia-pro#2400]