### PR TITLE
fix: force update request after rollback

### DIFF
--- a/src/Modules/Rollback.php
+++ b/src/Modules/Rollback.php
@@ -375,10 +375,26 @@ class Rollback extends Abstract_Module {
 	}
 
 	/**
+	 * Fires after the option has been updated.
+	 *
+	 * @param mixed  $old_value The old option value.
+	 * @param mixed  $value     The new option value.
+	 * @param string $option    Option name.
+	 */
+	public function update_active_plugins_action( $old_value, $value, $option ) {
+		delete_site_transient( 'update_plugins' );
+		wp_cache_delete( 'plugins', 'plugins' );
+	}
+
+	/**
 	 * Set the rollback hook. Strangely, this does not work if placed in the ThemeIsle_SDK_Rollback class, so it is being called from there instead.
 	 */
 	public function add_hooks() {
 		add_action( 'admin_post_' . $this->product->get_key() . '_rollback', array( $this, 'start_rollback' ) );
 		add_action( 'admin_footer', array( $this, 'add_footer' ) );
+
+		// This hook will be invoked after the plugin activation.
+		// We use this to force an update of the cache so that Update is present immediate after a rollback.
+		add_action( 'update_option_active_plugins', array( $this, 'update_active_plugins_action' ), 10, 3 );
 	}
 }


### PR DESCRIPTION
The issue that this PR should handle is that it will force a plugin update check after a rollback.
Right now after a rollback is handled the Update action is not present unless the cron for updates will execute witch is twice a day or a manual `delete_site_transient( 'update_plugins' );` is executed.

I've tried to explicitly invoke `delete_site_transient( 'update_plugins' );` after the rollback here: https://github.com/Codeinwp/themeisle-sdk/blob/e5c171e33120fdf8ce6dd3a7bddad984583023f0/src/Modules/Rollback.php#L245-L253

But it looks like since the plugin might be deactivated at this point as some actions are async it does not work.

Hence I looked into hooking in an action that happens after activation, there was a hook `do_action( 'activated_plugin', $plugin, $network_wide );` but this does not execute in silent mode witch is the mode used during a rollback. More info [here](https://github.com/WordPress/wordpress-develop/blob/b38c2fb5e98e9b849a50e808932826349b994fa7/src/wp-admin/includes/plugin.php#L703-L717)

From reading the core for the `Plugin Upgrader` it should clean this automatically upon upgrade but as mentioned previously I think in the context of the rollback the transient is not cleaned up correctly.

So the solution I propose is to trigger an update cache clean after a plugin activation if the themeisle-sdk is present.
It is not the ideal in my opinion but I don't see another way of achieving this from my experimentation.

## Testing:
1. Use this PR's version of the Themeisle SDK, make sure is the same for Neve and Neve Pro
2. Rollback Neve Pro to a previous version
3. Check that after rollback the update is present

References: Codeinwp/neve-pro-addon/issues/1678

I think it will also work for: Codeinwp/neve-pro-addon/issues/1677