### PR TITLE
fix: solve rollback sometimes not available

### DIFF
--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -523,7 +523,7 @@ class Licenser extends Abstract_Module {
 		}
 
 		// Remove the versions transient upon activation so that newer version for rollback can be acquired.
-		$versions_cache = $this->product->get_key() . '_' . preg_replace( '/[^0-9a-zA-Z ]/m', '', $this->product->get_version() ) . 'versions';
+		$versions_cache = $this->product->get_cache_key();
 		delete_transient( $versions_cache );
 
 		return true;

--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -522,6 +522,10 @@ class Licenser extends Abstract_Module {
 			return new \WP_Error( 'themeisle-license-invalid', 'ERROR: Invalid license provided.' );
 		}
 
+        // Remove the versions transient upon activation so that newer version for rollback can be acquired.
+		$versions_cache = $this->product->get_key() . '_' . preg_replace( '/[^0-9a-zA-Z ]/m', '', $this->product->get_version() ) . 'versions';
+		delete_transient( $versions_cache );
+
 		return true;
 	}
 

--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -522,7 +522,7 @@ class Licenser extends Abstract_Module {
 			return new \WP_Error( 'themeisle-license-invalid', 'ERROR: Invalid license provided.' );
 		}
 
-        // Remove the versions transient upon activation so that newer version for rollback can be acquired.
+		// Remove the versions transient upon activation so that newer version for rollback can be acquired.
 		$versions_cache = $this->product->get_key() . '_' . preg_replace( '/[^0-9a-zA-Z ]/m', '', $this->product->get_version() ) . 'versions';
 		delete_transient( $versions_cache );
 

--- a/src/Modules/Rollback.php
+++ b/src/Modules/Rollback.php
@@ -98,7 +98,7 @@ class Rollback extends Abstract_Module {
 	 */
 	private function get_api_versions() {
 
-		$cache_key      = $this->product->get_key() . '_' . preg_replace( '/[^0-9a-zA-Z ]/m', '', $this->product->get_version() ) . 'versions';
+		$cache_key      = $this->product->get_cache_key();
 		$cache_versions = get_transient( $cache_key );
 		if ( false === $cache_versions ) {
 			$versions = $this->get_remote_versions();

--- a/src/Modules/Rollback.php
+++ b/src/Modules/Rollback.php
@@ -102,9 +102,7 @@ class Rollback extends Abstract_Module {
 		$cache_versions = get_transient( $cache_key );
 		if ( false === $cache_versions ) {
 			$versions = $this->get_remote_versions();
-			if ( ! empty( $versions ) ) {
-				set_transient( $cache_key, $versions, 5 * DAY_IN_SECONDS );
-			}
+			set_transient( $cache_key, $versions, 5 * DAY_IN_SECONDS );
 		} else {
 			$versions = is_array( $cache_versions ) ? $cache_versions : array();
 		}

--- a/src/Modules/Rollback.php
+++ b/src/Modules/Rollback.php
@@ -102,7 +102,9 @@ class Rollback extends Abstract_Module {
 		$cache_versions = get_transient( $cache_key );
 		if ( false === $cache_versions ) {
 			$versions = $this->get_remote_versions();
-			set_transient( $cache_key, $versions, 5 * DAY_IN_SECONDS );
+			if ( ! empty( $versions ) ) {
+				set_transient( $cache_key, $versions, 5 * DAY_IN_SECONDS );
+			}
 		} else {
 			$versions = is_array( $cache_versions ) ? $cache_versions : array();
 		}

--- a/src/Product.php
+++ b/src/Product.php
@@ -323,6 +323,15 @@ class Product {
 	}
 
 	/**
+	 * Return the product version cache key.
+	 *
+	 * @return string The product version cache key.
+	 */
+	public function get_cache_key() {
+		return $this->get_key() . '_' . preg_replace( '/[^0-9a-zA-Z ]/m', '', $this->get_version() ) . 'versions';
+	}
+
+	/**
 	 * Getter for product name.
 	 *
 	 * @return string The product name.


### PR DESCRIPTION
If the license is not active as soon as the plugin is activated it will set the transient with an empty array.
This will prevent the user from rolling back until the transient expires or it is removed.

Another solution that I would see for this is to have a smaller transient for an empty response, instead of 5 days maybe 12 hours. This way if the response is empty, it will check again after 12 hours and if the response is valid it will update the response in 5 days as before.

### Test instructions
1. Install the Neve Pro plugin
2. Use this version of the SDK
3. Check that the Rollback is not present
4. Activate the plugin, the rollback should become available.

References: Codeinwp/neve-pro-addon#1878