### PR TITLE
Feat/allow product name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### [Version 3.2.30](https://github.com/Codeinwp/themeisle-sdk/compare/v3.2.29...v3.2.30) (2022-09-15)
+
+- fix filesystem wrong use - ref [#138](https://github.com/Codeinwp/themeisle-sdk/issues/138), props [@ethanclevenger91](https://github.com/ethanclevenger91) for reporting
+
 ##### [Version 3.2.29](https://github.com/Codeinwp/themeisle-sdk/compare/v3.2.28...v3.2.29) (2022-09-08)
 
 * Adds compatibility mechanism

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
       "homepage": "https://themeisle.com"
     }
   ],
-  "version": "3.2.29",
+  "version": "3.2.30",
   "require-dev": {
     "codeinwp/phpcs-ruleset": "dev-main"
   },

--- a/load.php
+++ b/load.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 // Current SDK version and path.
-$themeisle_sdk_version = '3.2.29';
+$themeisle_sdk_version = '3.2.30';
 $themeisle_sdk_path    = dirname( __FILE__ );
 
 global $themeisle_sdk_max_version;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "themeisle-sdk",
   "description": "Themeisle SDK",
-  "version": "3.2.29",
+  "version": "3.2.30",
   "scripts": {
     "start": "wp-scripts start assets/js/src/index.js --output-path=assets/js/build",
     "build": "wp-scripts build assets/js/src/index.js --output-path=assets/js/build",

--- a/src/Product.php
+++ b/src/Product.php
@@ -207,7 +207,7 @@ class Product {
 		}
 		$file_headers = get_file_data( $this->basefile, $file_headers );
 
-		$name = apply_filters( 'themesle_sdk_product_name_' . md5( $this->basefile ), $file_headers['Name'] );
+		$name             = apply_filters( 'themesle_sdk_product_name_' . md5( $this->basefile ), $file_headers['Name'] );
 		$this->name       = $name;
 		$this->store_name = $file_headers['AuthorName'];
 		$this->author_url = $file_headers['AuthorURI'];

--- a/src/Product.php
+++ b/src/Product.php
@@ -207,7 +207,8 @@ class Product {
 		}
 		$file_headers = get_file_data( $this->basefile, $file_headers );
 
-		$this->name       = $file_headers['Name'];
+		$name = apply_filters( 'themesle_sdk_product_name_' . md5( $this->basefile ), $file_headers['Name'] );
+		$this->name       = $name;
 		$this->store_name = $file_headers['AuthorName'];
 		$this->author_url = $file_headers['AuthorURI'];
 		$this->store_url  = $file_headers['AuthorURI'];


### PR DESCRIPTION
I added a filter that allows changing the product name used during the licensing process.
I needed this for the Template Patterns Collection as the license is under a different name than the Plugin uses.