### PR TITLE
Fix/path promotions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### [Version 3.2.37](https://github.com/Codeinwp/themeisle-sdk/compare/v3.2.36...v3.2.37) (2023-03-01)
+
+Fix array casting
+
 ##### [Version 3.2.36](https://github.com/Codeinwp/themeisle-sdk/compare/v3.2.35...v3.2.36) (2023-03-01)
 
 fix perfomance issues on attachments count https://github.com/Codeinwp/themeisle-sdk/issues/159

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
       "homepage": "https://themeisle.com"
     }
   ],
-  "version": "3.2.36",
+  "version": "3.2.37",
   "require-dev": {
     "codeinwp/phpcs-ruleset": "dev-main"
   },

--- a/load.php
+++ b/load.php
@@ -29,7 +29,7 @@ if ( ! is_file( $themeisle_sdk_path . $themeisle_sdk_relative_licenser_path ) &&
 	add_filter( 'themeisle_sdk_required_files', 'themeisle_sdk_load_licenser_if_present' );
 }
 
-if ( ( is_null( $themeisle_sdk_max_path ) || version_compare( $themeisle_sdk_version, $themeisle_sdk_max_path ) == 0 ) &&
+if ( ( is_null( $themeisle_sdk_max_path ) || version_compare( $themeisle_sdk_version, $themeisle_sdk_max_version ) == 0 ) &&
 	apply_filters( 'themeisle_sdk_should_overwrite_path', false, $themeisle_sdk_path, $themeisle_sdk_max_path ) ) {
 	$themeisle_sdk_max_path = $themeisle_sdk_path;
 }

--- a/load.php
+++ b/load.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 // Current SDK version and path.
-$themeisle_sdk_version = '3.2.36';
+$themeisle_sdk_version = '3.2.37';
 $themeisle_sdk_path    = dirname( __FILE__ );
 
 global $themeisle_sdk_max_version;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "themeisle-sdk",
   "description": "Themeisle SDK",
-  "version": "3.2.36",
+  "version": "3.2.37",
   "scripts": {
     "dev": "npm run start",
     "start": "wp-scripts start assets/js/src/index.js --output-path=assets/js/build",

--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -201,7 +201,12 @@ class Promotions extends Abstract_Module {
 	private function get_sdk_uri() {
 		global $themeisle_sdk_max_path;
 
-		if ( $this->product->is_plugin() ) {
+		/**
+		 * $themeisle_sdk_max_path can point to the theme when the theme version is higher.
+		 * hence we also need to check that the path does not point to the theme else this will break the URL.
+		 * References: https://github.com/Codeinwp/neve-pro-addon/issues/2403
+		 */
+		if ( $this->product->is_plugin() && false === strpos( $themeisle_sdk_max_path, get_template_directory() ) ) {
 			return plugins_url( '/', $themeisle_sdk_max_path . '/themeisle-sdk/' );
 		};
 


### PR DESCRIPTION
### Summary:
Solve  `get_sdk_uri()` return when `$themeisle_sdk_max_path` points to a theme and the last loaded product is a plugin which is usually the case as themes are being loaded first.

Also did a small change to the condition in `load.php` as I think `version_compare()` should compare against `$themeisle_sdk_max_version` previously the `$themeisle_sdk_max_path` was used.

### How this can be tested?
1. Create a new instance where you are using a higher version of Neve than the Pro version. Eg. Free 3.5.3 and PRO 2.5.2
2. Check that when using Elementor or on Media where promotions should be loaded no errors are being thrown when using this SDK version.
3. To confirm it is working correctly check against the previous SDK version.

Closes: Codeinwp/neve-pro-addon#2403.