### PR TITLE
fix: for empty dismiss on promotions use install time #170

### DIFF
--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -333,7 +333,7 @@ class Promotions extends Abstract_Module {
 	 *
 	 * @param string $key The upsell key. If empty will return all dismiss times.
 	 *
-	 * @return false | string
+	 * @return false | string | array
 	 */
 	private function get_upsells_dismiss_time( $key = '' ) {
 		$old  = get_option( 'themeisle_sdk_promotions_otter', '{}' );
@@ -351,18 +351,18 @@ class Promotions extends Abstract_Module {
 	/**
 	 * Get the last dismiss time of a promotion.
 	 *
-	 * @return false
+	 * @return int The timestamp of last dismiss, or install time - 4 days.
 	 */
 	private function get_last_dismiss_time() {
 		$dismissed = $this->get_upsells_dismiss_time();
 
 		if ( empty( $dismissed ) ) {
-			return false;
+			// we return the product install time - 4 days because we want to show the upsell after 3 days,
+			// and we move the product install time 4 days in the past.
+			return $this->product->get_install_time() - 4 * DAY_IN_SECONDS;
 		}
 
-		$last_dismiss = max( array_values( $dismissed ) );
-
-		return $last_dismiss;
+		return max( array_values( $dismissed ) );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
For Promotions when no dismiss data is present the install time is now returned - 4 Days instead of empty.
Since we later check the time difference between the dismiss and the `time()` it will result in a value of 3 Days.
Previously the difference would evaluate to `time()` and the Promotion would get executed instantly.

Also did some small code cleanup.

Closes #170.