### PR TITLE
Feat/beta updates

### DIFF
--- a/src/Common/Module_factory.php
+++ b/src/Common/Module_factory.php
@@ -90,7 +90,10 @@ class Module_Factory {
 			 */
 			$module_object = new $class( $product );
 
-			if ( ! $module_object->can_load( $product ) ) {
+			// This will load the module if the product is in beta. This way free licensed products will receive updates via the store.
+			$allow_if_beta = $product->is_beta();
+
+			if ( ! $module_object->can_load( $product ) && $allow_if_beta === false ) {
 				continue;
 			}
 			self::$modules_attached[ $product->get_slug() ][ $module ] = $module_object->load( $product );

--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -773,16 +773,19 @@ class Licenser extends Abstract_Module {
 	 * @return bool|mixed Update api response.
 	 */
 	private function get_version_data() {
+		$allow_if_beta = $this->product->is_beta();
+		$version_url   = sprintf(
+			'%slicense/version/%s/%s/%s/%s%s',
+			Product::API_URL,
+			rawurlencode( $this->product->get_name() ),
+			( empty( $this->license_key ) ? 'free' : $this->license_key ),
+			$this->product->get_version(),
+			rawurlencode( home_url() ),
+			$allow_if_beta ? '/use_beta' : ''
+		);
 
 		$response = $this->safe_get(
-			sprintf(
-				'%slicense/version/%s/%s/%s/%s',
-				Product::API_URL,
-				rawurlencode( $this->product->get_name() ),
-				( empty( $this->license_key ) ? 'free' : $this->license_key ),
-				$this->product->get_version(),
-				rawurlencode( home_url() )
-			),
+			$version_url,
 			array(
 				'timeout'   => 15, //phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout, Inherited by wp_remote_get only, for vip environment we use defaults.
 				'sslverify' => false,
@@ -979,7 +982,7 @@ class Licenser extends Abstract_Module {
 						$new_actions['renew_link'] = '<a style="color:#d63638" href="' . esc_url( $this->renew_url() ) . '" target="_blank" rel="external noopener noreferrer">Renew license to update</a>';
 
 						return $new_actions;
-					} 
+					}
 				);
 			}
 

--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -774,15 +774,13 @@ class Licenser extends Abstract_Module {
 	 */
 	private function get_version_data() {
 		$allow_if_beta = $this->product->is_beta();
-
 		$version_url   = sprintf(
-			'%slicense/version/%s/%s/%s/%s/%s%s',
+			'%slicense/version/%s/%s/%s/%s%s',
 			Product::API_URL,
 			rawurlencode( $this->product->get_name() ),
 			( empty( $this->license_key ) ? 'free' : $this->license_key ),
 			$this->product->get_version(),
 			rawurlencode( home_url() ),
-			time(),
 			$allow_if_beta ? '/use_beta' : ''
 		);
 

--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -774,13 +774,15 @@ class Licenser extends Abstract_Module {
 	 */
 	private function get_version_data() {
 		$allow_if_beta = $this->product->is_beta();
+
 		$version_url   = sprintf(
-			'%slicense/version/%s/%s/%s/%s%s',
+			'%slicense/version/%s/%s/%s/%s/%s%s',
 			Product::API_URL,
 			rawurlencode( $this->product->get_name() ),
 			( empty( $this->license_key ) ? 'free' : $this->license_key ),
 			$this->product->get_version(),
 			rawurlencode( home_url() ),
+			time(),
 			$allow_if_beta ? '/use_beta' : ''
 		);
 

--- a/src/Product.php
+++ b/src/Product.php
@@ -223,6 +223,24 @@ class Product {
 		$this->pro_slug            = ! empty( $file_headers['Pro Slug'] ) ? $file_headers['Pro Slug'] : '';
 		$this->version             = $file_headers['Version'];
 
+		// will enable beta releases for the product and for the pro version using just the free slug.
+		$enable_beta_release = apply_filters( $this->get_slug() . '_sdk_enable_beta_release', false );
+		if ( $enable_beta_release === true ) {
+			add_filter( $this->get_slug() . '_sdk_allow_beta', '__return_true' );
+			if ( ! empty( $this->pro_slug ) ) {
+				add_filter( $this->pro_slug . '_sdk_allow_beta', '__return_true' );
+			}
+		}
+		// when the filter is changed, we need to refresh the transient data so that it reflects the changes.
+		$previous_beta_status = get_site_transient( $this->get_slug() . '_sdk_beta_status' );
+		if ( $previous_beta_status !== $enable_beta_release ) {
+			set_site_transient( $this->get_slug() . '_sdk_beta_status', (bool) $enable_beta_release, DAY_IN_SECONDS );
+			if ( ! empty( get_site_transient( $this->get_slug() . '-update-response' ) ) ) {
+				delete_site_transient( $this->get_slug() . '-update-response' );
+			}
+			delete_site_transient( 'update_plugins' );
+		}
+
 	}
 
 	/**
@@ -408,11 +426,20 @@ class Product {
 	 * @return string Changelog url.
 	 */
 	public function get_changelog() {
+		$query_args = array(
+			'name'       => rawurlencode( $this->get_name() ),
+			'edd_action' => 'view_changelog',
+		);
+
+		$api_response = get_transient( $this->get_key() . '-update-response' );
+		if ( ! empty( $api_response ) && isset( $api_response->new_version ) ) {
+			if ( strpos( $api_response->new_version, '-beta.' ) !== false ) {
+				$query_args['beta'] = '1';
+			}
+		}
+
 		return add_query_arg(
-			[
-				'name'       => rawurlencode( $this->get_name() ),
-				'edd_action' => 'view_changelog',
-			],
+			$query_args,
 			$this->get_store_url()
 		);
 	}
@@ -455,6 +482,15 @@ class Product {
 		if ( $this->type ) {
 			return plugins_url( $path, $this->basefile );
 		}
+	}
+
+	/**
+	 * Returns if the product beta is enabled or not.
+	 *
+	 * @return boolean
+	 */
+	public function is_beta() {
+		return apply_filters( $this->get_slug() . '_sdk_allow_beta', false );
 	}
 
 }


### PR DESCRIPTION
### Summary
Allow usage of filter:
```php
// General usage: add_filter( '<product_slug>_sdk_enable_beta_release', '__return_true' );
add_filter( 'neve_sdk_enable_beta_release', '__return_true' );
```

That will reset the transients for theme update and plugin update and allow pulling beta versions from the store.

It also will update the changelog URLs to pull for the beta changelog if enabled.

Full workflow and details can be found here: Codeinwp/store-themeisle/pull/564

Closes: Codeinwp/store-themeisle#551