### PR TITLE
Notifications for Neve FSE

### DIFF
--- a/src/Modules/Notification.php
+++ b/src/Modules/Notification.php
@@ -48,6 +48,12 @@ class Notification extends Abstract_Module {
 	 * Show notification data.
 	 */
 	public static function show_notification() {
+		global $pagenow;
+		$current_promotion = apply_filters( 'themeisle_sdk_current_promotion', '' );
+        $current_theme     = get_template();
+		if ( 'neve-fse' === $current_theme && 'neve-fse-themes-popular' === $current_promotion && 'themes.php' === $pagenow ) {
+			return;
+		}
 
 		$current_notification = self::get_last_notification();
 
@@ -443,7 +449,6 @@ class Notification extends Abstract_Module {
 	 * @return bool Should we load this?
 	 */
 	public function can_load( $product ) {
-
 		if ( $this->is_from_partner( $product ) ) {
 			return false;
 		}

--- a/src/Modules/Notification.php
+++ b/src/Modules/Notification.php
@@ -48,10 +48,10 @@ class Notification extends Abstract_Module {
 	 * Show notification data.
 	 */
 	public static function show_notification() {
-		global $pagenow;
 		$current_promotion = apply_filters( 'themeisle_sdk_current_promotion', '' );
-        $current_theme     = get_template();
-		if ( 'neve-fse' === $current_theme && 'neve-fse-themes-popular' === $current_promotion && 'themes.php' === $pagenow ) {
+		$current_theme     = get_template();
+		$screen            = get_current_screen();
+		if ( 'neve-fse' === $current_theme && 'neve-fse-themes-popular' === $current_promotion && 'themes' === $screen->id ) {
 			return;
 		}
 

--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -285,6 +285,7 @@ class Promotions extends Abstract_Module {
 		$has_ppom                = defined( 'PPOM_VERSION' ) || $this->is_plugin_installed( 'woocommerce-product-addon' );
 		$is_min_req_v            = version_compare( get_bloginfo( 'version' ), '5.8', '>=' );
 		$is_min_fse_v            = version_compare( get_bloginfo( 'version' ), '6.2', '>=' );
+		$has_neve_fse            = get_template() === 'neve-fse';
 		$has_enough_attachments  = $this->has_min_media_attachments();
 		$has_enough_old_posts    = $this->has_old_posts();
 
@@ -351,7 +352,7 @@ class Promotions extends Abstract_Module {
 			],
 			'neve-fse'    => [
 				'neve-fse-themes-popular' => [
-					'env'    => $is_min_fse_v,
+					'env'    => ! $has_neve_fse && $is_min_fse_v,
 					'screen' => 'themes-install-popular',
 				],
 			],
@@ -486,7 +487,12 @@ class Promotions extends Abstract_Module {
 	 */
 	private function load_promotion( $slug ) {
 		$this->loaded_promo = $slug;
-
+		add_filter(
+			'themeisle_sdk_current_promotion',
+			function() use ( $slug ) {
+				return $slug;
+			}
+		);
 		if ( $this->debug ) {
 			add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue' ] );
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );
@@ -784,7 +790,7 @@ class Promotions extends Abstract_Module {
 				);
 
 				return $tabs;
-			} 
+			}
 		);
 
 		add_action( 'woocommerce_product_data_panels', array( $this, 'woocommerce_tab_content' ) );
@@ -800,7 +806,7 @@ class Promotions extends Abstract_Module {
 			function( $key ) {
 				return in_array( $key, $this->promotions, true );
 			},
-			ARRAY_FILTER_USE_KEY 
+			ARRAY_FILTER_USE_KEY
 		);
 
 		// Display CSS

--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -285,7 +285,8 @@ class Promotions extends Abstract_Module {
 		$has_ppom                = defined( 'PPOM_VERSION' ) || $this->is_plugin_installed( 'woocommerce-product-addon' );
 		$is_min_req_v            = version_compare( get_bloginfo( 'version' ), '5.8', '>=' );
 		$is_min_fse_v            = version_compare( get_bloginfo( 'version' ), '6.2', '>=' );
-		$has_neve_fse            = get_template() === 'neve-fse';
+		$current_theme           = wp_get_theme();
+		$has_neve_fse            = $current_theme->template === 'neve-fse' || $current_theme->parent() === 'neve-fse';
 		$has_enough_attachments  = $this->has_min_media_attachments();
 		$has_enough_old_posts    = $this->has_old_posts();
 


### PR DESCRIPTION
This PR:
- changes the promotion for Neve FSE so it's not displayed when Neve FSE is installed.
- changes the notifications to not show any other message on the themes page if Neve FSE promo is enabled.

Please note that the notifications from SDK are appearing only after 100 hours after the activation. When testing this, you should either have an older instance or disable the following lines: https://github.com/Codeinwp/themeisle-sdk/blob/master/src/Modules/Notification.php#L453-L455

Closes Codeinwp/neve-fse#69.