### PR TITLE
Allow users to activate plugins from About page

### DIFF
--- a/assets/js/src/about/components/ProductCard.js
+++ b/assets/js/src/about/components/ProductCard.js
@@ -5,7 +5,7 @@ import {installPluginOrTheme} from "../../common/utils";
 
 export default function ProductCard({product, slug}) {
 	const {icon, name, description, status, premiumUrl, activationLink} = product;
-	const {strings, canInstallPlugins} = window.tiSDKAboutData;
+	const {strings, canInstallPlugins, canActivatePlugins } = window.tiSDKAboutData;
 	const {
 		installNow,
 		installed,
@@ -20,9 +20,6 @@ export default function ProductCard({product, slug}) {
 	const [loading, setLoading] = useState(false);
 
 	const runInstall = async () => {
-		if ( ! canInstallPlugins ) {
-			return;
-		}
 		setLoading(true);
 		await installPluginOrTheme(slug, slug === 'neve').then((res) => {
 			if (res.success) {
@@ -33,9 +30,6 @@ export default function ProductCard({product, slug}) {
 	}
 
 	const runActivate = async () => {
-		if ( ! canInstallPlugins ) {
-			return;
-		}
 		setLoading(true);
 		window.location.href = activationLink;
 	}
@@ -59,7 +53,7 @@ export default function ProductCard({product, slug}) {
 
 		if ( productStatus === 'installed' ) {
 			return (
-				<Button isSecondary onClick={runActivate} disabled={loading || ! canInstallPlugins}>
+				<Button isSecondary onClick={runActivate} disabled={loading || ! canActivatePlugins}>
 					{activate}
 				</Button>
 			)
@@ -68,8 +62,13 @@ export default function ProductCard({product, slug}) {
 		return null;
 	});
 
-	const wrappedButtonContent = ! canInstallPlugins ? (
-		<Tooltip text={`Ask your admin to enable ${name} on your site`} position="top center">{buttonContent()}</Tooltip>
+	const actionsAreDisabled =
+		(!canInstallPlugins && productStatus === 'not-installed') ||
+		(!canActivatePlugins && productStatus === 'installed' ) ||
+		false;
+
+	const wrappedButtonContent = actionsAreDisabled ? (
+		<Tooltip text={`Ask your admin to enable ${name} on your site ${productStatus}`} position="top center">{buttonContent()}</Tooltip>
 	) : (
 		buttonContent()
 	);

--- a/src/Modules/About_us.php
+++ b/src/Modules/About_us.php
@@ -203,7 +203,8 @@ class About_Us extends Abstract_Module {
 				'notInstalled'     => __( 'Not Installed', 'textdomain' ),
 				'active'           => __( 'Active', 'textdomain' ),
 			],
-			'canInstallPlugins' => current_user_can( 'install_plugins' ),
+			'canInstallPlugins'  => current_user_can( 'install_plugins' ),
+			'canActivatePlugins' => current_user_can( 'activate_plugins' ),
 		];
 	}
 


### PR DESCRIPTION
While working on a similar task, I realized I missed one case. If the super admin [enables the plugins in the administration menu](https://vertis.d.pr/i/RXiwvO) the admin should be able to activate a plugin but not install one. The plugin must be available in Dashboard -> Plugins.

Closes Codeinwp/neve#4071