### PR TITLE
Avoids conflicts with Enfold Theme

### DIFF
--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -269,6 +269,22 @@ class Promotions extends Abstract_Module {
 	}
 
 	/**
+	 * Third-party compatibility.
+	 * 
+	 * @return boolean
+	 */
+	private function has_conflicts() {
+		global $pagenow;
+	
+		// Editor notices aren't compatible with Enfold theme.
+		if ( defined( 'AV_FRAMEWORK_VERSION' ) && in_array( $pagenow, array( 'post.php', 'post-new.php' ) ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get promotions.
 	 *
 	 * @return array
@@ -359,7 +375,7 @@ class Promotions extends Abstract_Module {
 
 		foreach ( $all as $slug => $data ) {
 			foreach ( $data as $key => $conditions ) {
-				if ( ! $conditions['env'] ) {
+				if ( ! $conditions['env'] || $this->has_conflicts() ) {
 					unset( $all[ $slug ][ $key ] );
 
 					continue;


### PR DESCRIPTION
Closes: https://github.com/Codeinwp/WP-Cloudflare-Super-Page-Cache/issues/94

We avoid loading notices in Block Editor if the Enfold theme is activated to avoid the linked issue.

**Reproducing & Testing**

- Install Enfold Theme & [WP-Cloudflare-Super-Page-Cache](https://github.com/Codeinwp/WP-Cloudflare-Super-Page-Cache)
- Create a new Page, use the Advanced Editor Layout
- Add a Text Block from Content Elements and switch to its Text view
- You shouldn't be able to press the Space key when using the Text view
- The issue should be solved after using the SDK fix from here.
