### PR TITLE
fix: deprecating notice in Dashboard Widget

### DIFF
--- a/src/Modules/Dashboard_widget.php
+++ b/src/Modules/Dashboard_widget.php
@@ -322,6 +322,9 @@ class Dashboard_Widget extends Abstract_Module {
 
 			$items = $feed->get_items( 0, 5 );
 			$items = is_array( $items ) ? $items : [];
+
+			$items_normalized = [];
+
 			foreach ( $items as $item ) {
 				$items_normalized[] = array(
 					'title' => $item->get_title(),


### PR DESCRIPTION
closes https://github.com/Codeinwp/themeisle/issues/1584

How to test:

- Install the SDK and make sure the error mentioned in the issue doesn't appear
- You need to be on PHP 8.1 with debugging enabled