### PR TITLE
feat: add new filter for tsdk_utmify query arguments

### DIFF
--- a/load.php
+++ b/load.php
@@ -115,12 +115,13 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 			'utm_content'  => $content,
 		];
 		$query_arguments = apply_filters( 'tsdk_utmify_' . $filter_key, $url_args, $url );
-		return esc_url_raw(
+		$utmify_url      = esc_url_raw(
 			add_query_arg(
 				$query_arguments,
 				$url
 			)
 		);
+		return apply_filters('tsdk_utmify_url_' . $filter_key, $utmify_url, $url  );
 	}
 
 	add_filter( 'tsdk_utmify', 'tsdk_utmify', 10, 3 );

--- a/load.php
+++ b/load.php
@@ -90,8 +90,8 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 			$current_page = isset( $screen->id ) ? $screen->id : ( ( $screen === null ) ? 'non-admin' : $screen );
 			$current_page = sanitize_key( str_replace( '.php', '', $current_page ) );
 		}
-		$location = $location === null ? $current_page : $location;
-		$content  = sanitize_key(
+		$location        = $location === null ? $current_page : $location;
+		$content         = sanitize_key(
 			trim(
 				str_replace(
 					[
@@ -107,14 +107,14 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 				'/'
 			)
 		);
-		$filter_key = sanitize_key( $content );
-		$url_args   = [
+		$filter_key      = sanitize_key( $content );
+		$url_args        = [
 			'utm_source'   => 'wpadmin',
 			'utm_medium'   => $location,
 			'utm_campaign' => $area,
 			'utm_content'  => $content,
 		];
-		$query_arguments = apply_filters('tsdk_utmify_' . $filter_key, $url_args,$url );
+		$query_arguments = apply_filters( 'tsdk_utmify_' . $filter_key, $url_args, $url );
 		return esc_url_raw(
 			add_query_arg(
 				$query_arguments,

--- a/load.php
+++ b/load.php
@@ -121,7 +121,7 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 				$url
 			)
 		);
-		return apply_filters('tsdk_utmify_url_' . $filter_key, $utmify_url, $url  );
+		return apply_filters( 'tsdk_utmify_url_' . $filter_key, $utmify_url, $url );
 	}
 
 	add_filter( 'tsdk_utmify', 'tsdk_utmify', 10, 3 );

--- a/load.php
+++ b/load.php
@@ -102,21 +102,24 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 						'/upgrade',
 					],
 					'',
-					$url 
+					$url
 				),
-				'/' 
-			) 
+				'/'
+			)
 		);
+		$filter_key = sanitize_key( $content );
+		$url_args   = [
+			'utm_source'   => 'wpadmin',
+			'utm_medium'   => $location,
+			'utm_campaign' => $area,
+			'utm_content'  => $content,
+		];
+		$query_arguments = apply_filters('tsdk_utmify_' . $filter_key, $url_args,$url );
 		return esc_url_raw(
 			add_query_arg(
-				[
-					'utm_source'   => 'wpadmin',
-					'utm_medium'   => $location,
-					'utm_campaign' => $area,
-					'utm_content'  => $content,
-				],
-				$url 
-			) 
+				$query_arguments,
+				$url
+			)
 		);
 	}
 

--- a/tests/utmify-test.php
+++ b/tests/utmify-test.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * UTMIFY tests.
+ *
+ * @package ThemeIsleSDK
+ */
+
+/**
+ * Test utmify link class.
+ */
+class Utmify_Test extends WP_UnitTestCase {
+
+	const AFFILIATE_URL = 'https://affiliate/upgrade/url';
+
+
+	private function register_filter() {
+		add_filter( 'tsdk_utmify_examplecomlink', function ( $arguments, $url ) {
+			$arguments['new_arg'] = '_affiliate_id_';
+			return $arguments;
+		}, 11, 2 );
+	}
+
+
+	private function register_filter_url() {
+		add_filter( 'tsdk_utmify_url_examplecomlink', function ( $utmify_url, $url ) {
+			return self::AFFILIATE_URL;
+		}, 11, 2 );
+	}
+
+
+	public function test_utmify_plugin() {
+
+
+		$file = dirname( __FILE__ ) . '/sample_products/sample_plugin/plugin_file.php';
+
+		$product = new \ThemeisleSDK\Product( $file );
+
+		$link = tsdk_utmify( 'https://example.com/link', 'area', 'location' );
+
+		$this->assertEquals( 'https://example.com/link?utm_source=wpadmin&utm_medium=location&utm_campaign=area&utm_content=examplecomlink', $link );
+
+		$this->register_filter();
+
+		$link = tsdk_utmify( 'https://example.com/link', 'area', 'location' );
+
+		$this->assertEquals( 'https://example.com/link?utm_source=wpadmin&utm_medium=location&utm_campaign=area&utm_content=examplecomlink&new_arg=_affiliate_id_', $link );
+
+		$this->register_filter_url();
+
+		$link = tsdk_utmify( 'https://example.com/link', 'area', 'location' );
+
+		$this->assertEquals( self::AFFILIATE_URL, $link );
+
+	}
+
+}

--- a/tests/utmify-test.php
+++ b/tests/utmify-test.php
@@ -14,17 +14,27 @@ class Utmify_Test extends WP_UnitTestCase {
 
 
 	private function register_filter() {
-		add_filter( 'tsdk_utmify_examplecomlink', function ( $arguments, $url ) {
-			$arguments['new_arg'] = '_affiliate_id_';
-			return $arguments;
-		}, 11, 2 );
+		add_filter(
+			'tsdk_utmify_examplecomlink',
+			function ( $arguments, $url ) {
+				$arguments['new_arg'] = '_affiliate_id_';
+				return $arguments;
+			},
+			11,
+			2 
+		);
 	}
 
 
 	private function register_filter_url() {
-		add_filter( 'tsdk_utmify_url_examplecomlink', function ( $utmify_url, $url ) {
-			return self::AFFILIATE_URL;
-		}, 11, 2 );
+		add_filter(
+			'tsdk_utmify_url_examplecomlink',
+			function ( $utmify_url, $url ) {
+				return self::AFFILIATE_URL;
+			},
+			11,
+			2 
+		);
 	}
 
 


### PR DESCRIPTION
### Summary

Added a new filter to allow affiliates to attach additional tracking arguments to the URLs that use `tsdk_utmify`
Added a new filter to allow affiliates to replace the URL generated  by the `tsdk_utmify` function call.
Added unit tests for both filters.

### Hook usage example:

#### Filter to append query arguments to URLs generated by `tsdk_utmify`
```php
add_filter( 'tsdk_utmify_neve', function ( $arguments, $url ) {
	if ( ! str_contains( $url, 'themes/neve/upgrade' ) ) {
		return $arguments;
	}
	$arguments['sscid'] = '_affiliate_id_';
	return $arguments;
}, 11, 2 );
```

#### Filter to replace the URL generated by `tsdk_utmify`
```php
add_filter( 'tsdk_utmify_url_neve', function ( $utmify_url, $url ) {
	if ( ! str_contains( $url, 'themes/neve/upgrade' ) ) {
		return $utmify_url;
	}
	return 'https://affiliate/upgrade/url';
}, 11, 2 );
```

<details>
    <summary>Example mu-plugin file</summary>

```php
<?php
/**
 * Plugin Name: Affiliate
 * Description: Short description of your plugin here.
 * Author:      your name here
 * License:     GNU General Public License v3 or later
 * License URI: http://www.gnu.org/licenses/gpl-3.0.html
 */

add_filter( 'tsdk_utmify_neve', function ( $arguments, $url ) {
	if ( ! str_contains( $url, 'themes/neve/upgrade' ) ) {
		return $arguments;
	}
	$arguments['sscid'] = '_affiliate_id_';
	return $arguments;
}, 11, 2 );


add_filter( 'tsdk_utmify_url_neve', function ( $utmify_url, $url ) {
	if ( ! str_contains( $url, 'themes/neve/upgrade' ) ) {
		return $utmify_url;
	}
	return 'https://affiliate/upgrade/url';
}, 11, 2 );

```
</details>

### How to test
1. On a fresh instance of Neve with the SDK from this PR
2. Create a mu plugin file where you can load any of the filters (see **Example mu-plugin file** from above.)
3. Check that the upgrade URLs are replaced correctly.

Closes: Codeinwp/neve-pro-addon#2670