### PR TITLE
fix: license key not found under specific situations

### DIFF
--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -274,7 +274,11 @@ class Licenser extends Abstract_Module {
 	public static function create_license_hash( $key ) {
 		$data = self::get_license_data( $key );
 
-		return isset( $data->license ) ? wp_hash( $data->key ) : false;
+		if ( ! $data ) {
+			return false;
+		}
+
+		return isset( $data->key ) ? wp_hash( $data->key ) : false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes the issue reported by Irinel when activating Otter license from Neve license: https://github.com/Codeinwp/otter-blocks/pull/1953#issuecomment-1812231488