### PR TITLE
fix: php notice on failed xml feed

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,14 +6,12 @@
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
 >
-    <testsuites name="General Unit tests ( Requires PHP 5.4) ">
-        <testsuite>
+    <testsuites>
+        <testsuite name="General Unit tests ( Requires PHP 5.4) ">
             <directory phpVersion="5.4.0" phpVersionOperator=">=" suffix="-test.php">./tests/</directory>
             <exclude>./tests/old/</exclude>
         </testsuite>
-    </testsuites>
-    <testsuites name="Bail lower php versions( For PHP lower than 5.4) ">
-        <testsuite>
+        <testsuite name="Bail lower php versions( For PHP lower than 5.4) ">
             <directory phpVersion="5.4.0" phpVersionOperator="lt" suffix="-test.php">./tests/old/</directory>
         </testsuite>
     </testsuites>

--- a/src/Modules/Dashboard_widget.php
+++ b/src/Modules/Dashboard_widget.php
@@ -313,8 +313,36 @@ class Dashboard_Widget extends Abstract_Module {
 	 */
 	private function setup_feeds() {
 		if ( false === ( $items_normalized = get_transient( 'themeisle_sdk_feed_items' ) ) ) { //phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure
+			// Do not force the feed for the items in the sdk feeds list.
+			// this prevents showing notices if another plugin will force all SimplePie feeds to load, instead it will
+			// use the regular SimplePie validation and abort early if the feed is not valid.
+			$sdk_feeds = $this->feeds;
+			add_filter(
+				'wp_feed_options',
+				function ( $feed, $url ) use ( $sdk_feeds ) {
+					if ( defined( 'TI_SDK_PHPUNIT' ) && true === TI_SDK_PHPUNIT ) {
+						return true;
+					}
+
+					if ( ! is_string( $url ) && in_array( $url, $sdk_feeds, true ) ) {
+						$feed->force_feed( false );
+						return true;
+					}
+					if ( is_array( $url ) ) {
+						foreach ( $url as $feed_url ) {
+							if ( in_array( $feed_url, $sdk_feeds, true ) ) {
+								$feed->force_feed( false );
+								return true;
+							}
+						}
+					}
+					return true;
+				},
+				PHP_INT_MAX,
+				2
+			);
 			// Load SimplePie Instance.
-			$feed = fetch_feed( $this->feeds );
+			$feed = fetch_feed( $sdk_feeds );
 			// TODO report error when is an error loading the feed.
 			if ( is_wp_error( $feed ) ) {
 				return;

--- a/src/Modules/Dashboard_widget.php
+++ b/src/Modules/Dashboard_widget.php
@@ -317,26 +317,25 @@ class Dashboard_Widget extends Abstract_Module {
 			// this prevents showing notices if another plugin will force all SimplePie feeds to load, instead it will
 			// use the regular SimplePie validation and abort early if the feed is not valid.
 			$sdk_feeds = $this->feeds;
-			add_filter(
+			add_action(
 				'wp_feed_options',
 				function ( $feed, $url ) use ( $sdk_feeds ) {
 					if ( defined( 'TI_SDK_PHPUNIT' ) && true === TI_SDK_PHPUNIT ) {
-						return true;
+						return;
 					}
 
 					if ( ! is_string( $url ) && in_array( $url, $sdk_feeds, true ) ) {
 						$feed->force_feed( false );
-						return true;
+						return;
 					}
 					if ( is_array( $url ) ) {
 						foreach ( $url as $feed_url ) {
 							if ( in_array( $feed_url, $sdk_feeds, true ) ) {
 								$feed->force_feed( false );
-								return true;
+								return;
 							}
 						}
 					}
-					return true;
 				},
 				PHP_INT_MAX,
 				2

--- a/tests/dashboard-widget-test.php
+++ b/tests/dashboard-widget-test.php
@@ -58,4 +58,105 @@ class Dashboard_Widget_Test extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * Private function to set up a tmp file for error log.
+	 *
+	 * @return false|resource
+	 */
+	private function setup_tmp_error_log_file() {
+		$error_log_tmp_file = tmpfile();
+		error_reporting( E_ALL ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_error_reporting
+		ini_set( 'error_log', stream_get_meta_data( $error_log_tmp_file )['uri'] ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+
+		return $error_log_tmp_file;
+	}
+
+	/**
+	 * Set up the XML load for the dashboard widget.
+	 * To be used in the next tests.
+	 */
+	private function xml_load_setup() {
+		delete_transient( 'themeisle_sdk_feed_items' );
+		add_filter(
+			'themeisle_sdk_dashboard_widget_feeds',
+			function( $feeds ) {
+				return [ 'https://themeisle.com/feed/random_feed' ];
+			},
+			10,
+			1
+		);
+
+		// force the feed to be XML
+		add_action(
+			'wp_feed_options',
+			function ( SimplePie $feed, $url ) {
+				$feed->force_feed( true );
+			},
+			10,
+			2
+		);
+
+		$file    = dirname( __FILE__ ) . '/sample_products/sample_theme/style.css';
+		$product = new \ThemeisleSDK\Product( $file );
+		$module  = new \ThemeisleSDK\Modules\Dashboard_Widget();
+
+		// force the dashboard widget to load
+		add_filter( $product->get_slug() . '_load_dashboard_widget', '__return_true' );
+		add_filter( 'themeisle_sdk_hide_dashboard_widget', '__return_false', 9999 );
+
+		$module = $module->load( $product );
+
+
+		$module->render_dashboard_widget();
+	}
+
+	/**
+	 * Test that the output is clean even when the feed is forced to be XML.
+	 * As the feed will use the filter to not enforce XML load for defined SDK urls.
+	 */
+	public function test_notice_output_is_clean() {
+		// set error log to tmp file
+		$prev_error_reporting = ini_get( 'error_reporting' );
+		$prev_error_log       = ini_get( 'error_log' );
+		$error_log_tmp_file   = $this->setup_tmp_error_log_file();
+
+		$this->xml_load_setup();
+
+		$result = stream_get_contents( $error_log_tmp_file );
+
+		// Check that the output is clean.
+		$this->assertTrue( empty( $result ) );
+
+
+		// set error log back to normal
+		ini_set( 'error_reporting', $prev_error_reporting ); // phpcs:ignore WordPress.PHP.IniSet.error_reporting_Blacklisted
+		ini_set( 'error_log', $prev_error_log ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+	}
+
+	/**
+	 * Test that the notice is thrown when the feed is forced to be XML.
+	 * This test is here to validate the behaviour when the filter is not applied.
+	 */
+	public function test_notice_is_thrown_on_forced_xml() {
+
+		// set error log to tmp file, and define TI_SDK_PHPUNIT to true so that the filter is not applied.
+		define( 'TI_SDK_PHPUNIT', true );
+		$prev_error_reporting = ini_get( 'error_reporting' );
+		$prev_error_log       = ini_get( 'error_log' );
+		$error_log_tmp_file   = $this->setup_tmp_error_log_file();
+
+		$this->xml_load_setup();
+
+		$result = stream_get_contents( $error_log_tmp_file );
+
+		// Check that the notice is thrown when the feed is forced to be XML.
+		$this->assertStringContainsString( 'PHP Notice:', $result );
+		$this->assertStringContainsString( 'is invalid XML, likely due to invalid characters. XML error:', $result );
+
+
+		// set error log back to normal
+		ini_set( 'error_reporting', $prev_error_reporting ); // phpcs:ignore WordPress.PHP.IniSet.error_reporting_Blacklisted
+		ini_set( 'error_log', $prev_error_log ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+	}
+
 }


### PR DESCRIPTION
### Summary
The issue reported was that there were cases when PHP Notice would be logged if the SDK feed failed. This would happen on edge cases where the SimplePIe library would have the `force_feed` attribute set as `true` by another plugin or theme using the `wp_feed_options` hook.

To account for that we register a hook as late as possible and set the value as explicit to `false` so that the regular SimplePie validation and workflow is used for the URLs set as feeds for the dashboard widget from the SDK.

I made minor changes to the `phpunit.xml` file as the previous syntax was incorrect.
I added 2 tests to validate that the notice is not triggered anymore and a test to validate the behaviour without the current fix.

### MU-Plugin File
<details>
    <summary>sdk-enable-feed.php</summary>

```php
/**
* Plugin Name:       Enable Themeisle SDK FEED
* Description:       This plugin is only used to enable themeisle SDK feed
* Version:           1.0.0
* Plugin URI:        https://themeisle.com/themes/neve/
* Author:            ThemeIsle
* Author URI:        https://themeisle.com
* License:           GPLv3
* License URI:       https://www.gnu.org/licenses/gpl-3.0.en.html
* Text Domain:       sdk-feed-enable
* Domain Path:       /languages
* Requires PHP:      7.4
* WordPress Available:  yes
* Requires License:    no
*
* @package Enable Themeisle SDK FEED
*/

/**
 * Define cli namespace for sdk.
 *
 * @return string CLI namespace.
 */
function sdk_enable_plugin_load_namespace() {
	return 'sdk-enable-feed';
}

/**
 * Filter products array.
 *
 * @param array $products products array.
 *
 * @return array
 */
function sdk_enable_plugin_load_sdk( $products ) {
	$products[] = __FILE__;

	return $products;
}

add_filter( 'themeisle_sdk_products', 'sdk_enable_plugin_load_sdk' );
add_filter( 'themesle_sdk_namespace_' . md5( __FILE__ ), 'sdk_enable_plugin_load_namespace' );
add_filter( 'mu-plugins_load_dashboard_widget', '__return_true' );
add_filter( 'themeisle_sdk_hide_dashboard_widget', '__return_false', 9999 );
add_filter( 'themeisle_sdk_dashboard_widget_feeds', function( $feeds ) {
	$feeds = [ 'https://themeisle.com/feed/random_feed' ];
	return $feeds;
}, 10, 1 );

add_action( 'wp_feed_options', function ( SimplePie $feed, $url ) {
	$feed->force_feed( true );
}, 10, 2 );
```
</details>

### How to test
1. Use the SDK build and create a file `sdk-enable-feed.php` with the contents from above, this file can be placed in the `mu-plugins`. It will enable the feed and set the condition so the notice should trigger in the logs.
2. Check that no notice is presented inside PHP logs
3. Check that when using a previous version of the SDK this is happening with the exact setup.


Closes: Codeinwp/themeisle#1604