### PR TITLE
fix: prevent reference key set for users with no capability

### DIFF
--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -173,6 +173,10 @@ class Promotions extends Abstract_Module {
 	 * @return void
 	 */
 	public function register_reference() {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
 		if ( isset( $_GET['reference_key'] ) ) {
 			update_option( 'otter_reference_key', sanitize_key( $_GET['reference_key'] ) );
 		}
@@ -269,12 +273,12 @@ class Promotions extends Abstract_Module {
 
 	/**
 	 * Third-party compatibility.
-	 * 
+	 *
 	 * @return boolean
 	 */
 	private function has_conflicts() {
 		global $pagenow;
-	
+
 		// Editor notices aren't compatible with Enfold theme.
 		if ( defined( 'AV_FRAMEWORK_VERSION' ) && in_array( $pagenow, array( 'post.php', 'post-new.php' ) ) ) {
 			return true;

--- a/tests/promotion-test.php
+++ b/tests/promotion-test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Promotion module feature test.
+ *
+ * @package ThemeIsleSDK
+ */
+
+/**
+ * Test Promotion feature.
+ */
+class Promotion_Test extends WP_UnitTestCase {
+	/**
+	 * Author user ID.
+	 *
+	 * @var int $author_id
+	 */
+	private $author_id;
+
+	/**
+	 * Set up.
+	 * Create a test user.
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->author_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * Tear down.
+	 * Remove the user.
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		wp_delete_user( $this->author_id, true );
+	}
+
+	/**
+	 * Test the CSRF protection when setting the reference_key
+	 *
+	 * @return void
+	 */
+	public function testCSRFOptionUpdate() {
+		$promotions = new \ThemeisleSDK\Modules\Promotions();
+		$option_key = 'otter_reference_key';
+
+		$option = get_option( $option_key );
+		$this->assertEmpty( $option );
+
+		wp_set_current_user( $this->author_id );
+
+		// Check non-capable users can not update the option.
+		$_GET['reference_key'] = 'test';
+		$promotions->register_reference();
+		$option = get_option( $option_key );
+		$this->assertEmpty( $option );
+
+		wp_set_current_user( 1 );
+
+		// Check capable users can update the option.
+		$promotions->register_reference();
+		$option = get_option( $option_key );
+		$this->assertEquals( 'test', $option );
+	}
+}


### PR DESCRIPTION
### Summary
Disallow users without proper capability from setting the `reference_key` used within Promotions.

### How to test
You can check the linked issue for full details.

Closes: Codeinwp/themeisle#1618