### PR TITLE
fix: added nonce check on reference key update

### DIFF
--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -177,14 +177,14 @@ class Promotions extends Abstract_Module {
 			return;
 		}
 
-        if ( ! isset( $_GET['plugin'] ) || ! isset( $_GET['_wpnonce'] ) ) {
-            return;
-        }
+		if ( ! isset( $_GET['plugin'] ) || ! isset( $_GET['_wpnonce'] ) ) {
+			return;
+		}
 
-        $plugin = rawurldecode( $_GET['plugin'] );
-        if ( wp_verify_nonce( $_GET['_wpnonce'], 'activate-plugin_' . $plugin ) === false ) {
-            return;
-        }
+		$plugin = rawurldecode( $_GET['plugin'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( wp_verify_nonce( $_GET['_wpnonce'], 'activate-plugin_' . $plugin ) === false ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			return;
+		}
 
 		if ( isset( $_GET['reference_key'] ) ) {
 			update_option( 'otter_reference_key', sanitize_key( $_GET['reference_key'] ) );

--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -177,6 +177,15 @@ class Promotions extends Abstract_Module {
 			return;
 		}
 
+        if ( ! isset( $_GET['plugin'] ) || ! isset( $_GET['_wpnonce'] ) ) {
+            return;
+        }
+
+        $plugin = rawurldecode( $_GET['plugin'] );
+        if ( wp_verify_nonce( $_GET['_wpnonce'], 'activate-plugin_' . $plugin ) === false ) {
+            return;
+        }
+
 		if ( isset( $_GET['reference_key'] ) ) {
 			update_option( 'otter_reference_key', sanitize_key( $_GET['reference_key'] ) );
 		}

--- a/tests/promotion-test.php
+++ b/tests/promotion-test.php
@@ -66,8 +66,8 @@ class Promotion_Test extends WP_UnitTestCase {
 		$this->assertEmpty( $option );
 
 		// Check capable users with valid nonce can update the option.
-		$plugin = 'otter-blocks/otter-blocks.php';
-		$_GET['plugin'] = rawurlencode( $plugin );
+		$plugin           = 'otter-blocks/otter-blocks.php';
+		$_GET['plugin']   = rawurlencode( $plugin );
 		$_GET['_wpnonce'] = wp_create_nonce( 'activate-plugin_' . $plugin );
 		$promotions->register_reference();
 		$option = get_option( $option_key );

--- a/tests/promotion-test.php
+++ b/tests/promotion-test.php
@@ -60,7 +60,15 @@ class Promotion_Test extends WP_UnitTestCase {
 
 		wp_set_current_user( 1 );
 
-		// Check capable users can update the option.
+		// Check capable users with invalid nonce can't update the option.
+		$promotions->register_reference();
+		$option = get_option( $option_key );
+		$this->assertEmpty( $option );
+
+		// Check capable users with valid nonce can update the option.
+		$plugin = 'otter-blocks/otter-blocks.php';
+		$_GET['plugin'] = rawurlencode( $plugin );
+		$_GET['_wpnonce'] = wp_create_nonce( 'activate-plugin_' . $plugin );
 		$promotions->register_reference();
 		$option = get_option( $option_key );
 		$this->assertEquals( 'test', $option );


### PR DESCRIPTION
### Summary
Added the `nonce` check also before allowing option update.
Modified test to also check for this.

### Screenshot
<img width="880" alt="image" src="https://github.com/Codeinwp/themeisle-sdk/assets/23024731/a664218e-7ce3-4ed1-9ab0-dbce2267e7bd">

### How to test
1. Check that if visiting the url `wp-admin/plugins.php?plugin_status=all&paged=1&action=activate&reference_key=neve&plugin=otter-blocks%2Fotter-blocks.php` the `otter_reference_key` does not get updated.
2. Go to an About us page, check that when activating the `Otter` plugin the `otter_reference_key` will be updated.

Closes: Codeinwp/themeisle#1618