### PR TITLE
feat: list featured plugins for pro products

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -61,6 +61,7 @@ final class Loader {
 		'compatibilities',
 		'about_us',
 		'announcements',
+		'featured_plugins',
 	];
 
 	/**

--- a/src/Modules/Featured_plugins.php
+++ b/src/Modules/Featured_plugins.php
@@ -65,6 +65,12 @@ class Featured_Plugins extends Abstract_Module {
 			return;
 		}
 
+		// bail if we already registered a filter for the plugin API.
+		if ( apply_filters( 'themeisle_sdk_plugin_api_filter_registered', false ) ) {
+			return;
+		}
+		add_filter( 'themeisle_sdk_plugin_api_filter_registered', '__return_true' );
+
 		add_filter( 'plugins_api_result', [ $this, 'filter_plugin_api_results' ], 10, 3 );
 	}
 
@@ -106,13 +112,16 @@ class Featured_Plugins extends Abstract_Module {
 	private function query_plugins_by_author( $args ) {
 		$featured = [];
 
-		$optimole_filter_slugs  = apply_filters( 'themeisle_sdk_optimole_filter_slugs', [ 'optimole-wp' ] );
+		$optimole_filter_slugs = apply_filters( 'themeisle_sdk_optimole_filter_slugs', [ 'optimole-wp' ] );
+		error_log( var_export( $optimole_filter_slugs, true ) );
 		$filtered_from_optimole = $this->get_plugins_filtered_from_author( $args, $optimole_filter_slugs, 'Optimole' );
 		$featured               = array_merge( $featured, $filtered_from_optimole );
 
 		$themeisle_filter_slugs  = apply_filters( 'themeisle_sdk_themeisle_filter_slugs', [ 'otter-blocks' ] );
 		$filtered_from_themeisle = $this->get_plugins_filtered_from_author( $args, $themeisle_filter_slugs );
 		$featured                = array_merge( $featured, $filtered_from_themeisle );
+
+		// error_log( var_export( $featured, true ) );
 
 		return $featured;
 	}

--- a/src/Modules/Featured_plugins.php
+++ b/src/Modules/Featured_plugins.php
@@ -112,16 +112,13 @@ class Featured_Plugins extends Abstract_Module {
 	private function query_plugins_by_author( $args ) {
 		$featured = [];
 
-		$optimole_filter_slugs = apply_filters( 'themeisle_sdk_optimole_filter_slugs', [ 'optimole-wp' ] );
-		error_log( var_export( $optimole_filter_slugs, true ) );
+		$optimole_filter_slugs  = apply_filters( 'themeisle_sdk_optimole_filter_slugs', [ 'optimole-wp' ] );
 		$filtered_from_optimole = $this->get_plugins_filtered_from_author( $args, $optimole_filter_slugs, 'Optimole' );
 		$featured               = array_merge( $featured, $filtered_from_optimole );
 
 		$themeisle_filter_slugs  = apply_filters( 'themeisle_sdk_themeisle_filter_slugs', [ 'otter-blocks' ] );
 		$filtered_from_themeisle = $this->get_plugins_filtered_from_author( $args, $themeisle_filter_slugs );
 		$featured                = array_merge( $featured, $filtered_from_themeisle );
-
-		// error_log( var_export( $featured, true ) );
 
 		return $featured;
 	}

--- a/src/Modules/Featured_plugins.php
+++ b/src/Modules/Featured_plugins.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * File responsible for showing plugins inside the featured tab.
+ *
+ * This is used to display information about limited events, such as Black Friday.
+ *
+ * @package     ThemeIsleSDK
+ * @subpackage  Modules
+ * @copyright   Copyright (c) 2017, Marius Cristea
+ * @license     http://opensource.org/licenses/gpl-3.0.php GNU Public License
+ * @since       3.3.0
+ */
+namespace ThemeisleSDK\Modules;
+
+use ThemeisleSDK\Common\Abstract_Module;
+use ThemeisleSDK\Product;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Featured_Plugins module for the ThemeIsle SDK.
+ */
+class Featured_Plugins extends Abstract_Module {
+
+	/**
+	 * The transient key prefix.
+	 *
+	 * @var string $transient_key
+	 */
+	private $transient_key = 'themeisle_sdk_featured_plugins_';
+
+	/**
+	 * Check if the module can be loaded.
+	 *
+	 * @param Product $product Product data.
+	 *
+	 * @return bool
+	 */
+	public function can_load( $product ) {
+		if ( $this->is_from_partner( $product ) ) {
+			return false;
+		}
+
+		$slug = $product->get_slug();
+		// only load for products that contain "pro" in the slug.
+		if ( strpos( $slug, 'pro' ) === false ) {
+			return false;
+		}
+
+		return ! apply_filters( 'themeisle_sdk_disable_featured_plugins', false );
+	}
+
+	/**
+	 * Load the module for the selected product.
+	 *
+	 * @param Product $product Product data.
+	 *
+	 * @return void
+	 */
+	public function load( $product ) {
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return;
+		}
+
+		add_filter( 'plugins_api_result', [ $this, 'filter_plugin_api_results' ], 10, 3 );
+	}
+
+	/**
+	 * Filter the plugin API results to include the featured plugins.
+	 *
+	 * @param object $res    The result object.
+	 * @param string $action The type of information being requested from the Plugin Install API.
+	 * @param object $args   Plugin API arguments.
+	 *
+	 * @return object
+	 */
+	public function filter_plugin_api_results( $res, $action, $args ) {
+
+		if ( 'query_plugins' !== $action ) {
+			return $res;
+		}
+
+		if ( ! isset( $args->browse ) || $args->browse !== 'featured' ) {
+			return $res;
+		}
+
+		$featured = $this->query_plugins_by_author( $args );
+
+		$plugins      = array_merge( $featured, $res->plugins );
+		$plugins      = array_slice( $plugins, 0, $res->info['results'] );
+		$res->plugins = $plugins;
+
+		return $res;
+	}
+
+	/**
+	 * Query plugins by author.
+	 *
+	 * @param object $args The arguments for the query.
+	 *
+	 * @return array
+	 */
+	private function query_plugins_by_author( $args ) {
+		$featured = [];
+
+		$optimole_filter_slugs  = apply_filters( 'themeisle_sdk_optimole_filter_slugs', [ 'optimole-wp' ] );
+		$filtered_from_optimole = $this->get_plugins_filtered_from_author( $args, $optimole_filter_slugs, 'Optimole' );
+		$featured               = array_merge( $featured, $filtered_from_optimole );
+
+		$themeisle_filter_slugs  = apply_filters( 'themeisle_sdk_themeisle_filter_slugs', [ 'otter-blocks' ] );
+		$filtered_from_themeisle = $this->get_plugins_filtered_from_author( $args, $themeisle_filter_slugs );
+		$featured                = array_merge( $featured, $filtered_from_themeisle );
+
+		return $featured;
+	}
+
+	/**
+	 * Get plugins filtered from an author.
+	 *
+	 * @param object $args          The arguments for the query.
+	 * @param array  $filter_slugs  The slugs to filter.
+	 * @param string $author        The author to filter.
+	 *
+	 * @return array
+	 */
+	private function get_plugins_filtered_from_author( $args, $filter_slugs = [], $author = 'Themeisle' ) {
+
+		$cached = get_transient( $this->transient_key . $author );
+		if ( $cached ) {
+			return $cached;
+		}
+
+		$new_args = [
+			'page'       => 1,
+			'per_page'   => 36,
+			'locale'     => get_user_locale(),
+			'author'     => $author,
+			'wp_version' => isset( $args->wp_version ) ? $args->wp_version : get_bloginfo( 'version' ),
+		];
+
+		$api = plugins_api( 'query_plugins', $new_args );
+		if ( is_wp_error( $api ) ) {
+			return [];
+		}
+
+		$filtered = array_filter(
+			$api->plugins,
+			function( $plugin ) use ( $filter_slugs ) {
+				return in_array( $plugin['slug'], $filter_slugs );
+			}
+		);
+
+		set_transient( $this->transient_key . $author, $filtered, 12 * HOUR_IN_SECONDS );
+
+		return $filtered;
+	}
+}

--- a/start.php
+++ b/start.php
@@ -38,6 +38,7 @@ $files_to_load          = [
 	$themeisle_library_path . '/src/Modules/Compatibilities.php',
 	$themeisle_library_path . '/src/Modules/About_us.php',
 	$themeisle_library_path . '/src/Modules/Announcements.php',
+	$themeisle_library_path . '/src/Modules/Featured_plugins.php',
 ];
 
 $files_to_load = array_merge( $files_to_load, apply_filters( 'themeisle_sdk_required_files', [] ) );

--- a/tests/featured-plugins-test.php
+++ b/tests/featured-plugins-test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Featured Plugins module tests.
+ *
+ * @package ThemeIsleSDK
+ */
+
+/**
+ * Test Featured Plugins loading.
+ */
+class Featured_Plugins_Test extends WP_UnitTestCase {
+
+	private static $admin_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		wp_set_current_user( self::$admin_id );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+	}
+
+	/**
+	 * Test plugin not loading without config.
+	 */
+	public function test_plugin_not_loading_if_not_pro() {
+		$plugin         = dirname( __FILE__ ) . '/sample_products/sample_plugin/plugin_file.php';
+		$plugin_product = new \ThemeisleSDK\Product( $plugin );
+
+		$this->assertFalse( ( new \ThemeisleSDK\Modules\Featured_Plugins() )->can_load( $plugin_product ) );
+	}
+
+	/**
+	 * Test plugin loading for pro.
+	 */
+	public function test_plugin_loading_for_pro() {
+		$plugin         = dirname( __FILE__ ) . '/sample_products/sample_pro_plugin/plugin_file.php';
+		$plugin_product = new \ThemeisleSDK\Product( $plugin );
+
+		$this->assertTrue( ( new \ThemeisleSDK\Modules\Featured_Plugins() )->can_load( $plugin_product ) );
+	}
+
+	/**
+	 * Test plugin not loading for pro if disabled.
+	 */
+	public function test_plugin_not_loading_for_pro_disabled() {
+		$plugin         = dirname( __FILE__ ) . '/sample_products/sample_pro_plugin/plugin_file.php';
+		$plugin_product = new \ThemeisleSDK\Product( $plugin );
+
+		add_filter( 'themeisle_sdk_disable_featured_plugins', '__return_true' );
+
+		$this->assertFalse( ( new \ThemeisleSDK\Modules\Featured_Plugins() )->can_load( $plugin_product ) );
+	}
+
+	/**
+	 * Test the filter is added.
+	 */
+	public function test_plugins_api_result_filter_added() {
+		wp_set_current_user( self::$admin_id );
+		$plugin         = dirname( __FILE__ ) . '/sample_products/sample_pro_plugin/plugin_file.php';
+		$plugin_product = new \ThemeisleSDK\Product( $plugin );
+
+		$module = new \ThemeisleSDK\Modules\Featured_Plugins();
+		$module->load( $plugin_product );
+
+		$this->assertTrue( (bool) has_filter( 'plugins_api_result', [ $module, 'filter_plugin_api_results' ] ) );
+	}
+
+}

--- a/tests/featured-plugins-test.php
+++ b/tests/featured-plugins-test.php
@@ -72,4 +72,25 @@ class Featured_Plugins_Test extends WP_UnitTestCase {
 		$this->assertTrue( (bool) has_filter( 'plugins_api_result', [ $module, 'filter_plugin_api_results' ] ) );
 	}
 
+	/**
+	 * Test the filter is not added if already registered.
+	 */
+	public function test_plugins_api_will_not_add_filter_if_marked_as_registered() {
+		wp_set_current_user( self::$admin_id );
+		$plugin         = dirname( __FILE__ ) . '/sample_products/sample_pro_plugin/plugin_file.php';
+		$plugin_product = new \ThemeisleSDK\Product( $plugin );
+
+		add_filter( 'themeisle_sdk_plugin_api_filter_registered', '__return_true' );
+
+		$module = new \ThemeisleSDK\Modules\Featured_Plugins();
+		$module->load( $plugin_product );
+
+		$this->assertFalse( (bool) has_filter( 'plugins_api_result', [ $module, 'filter_plugin_api_results' ] ) );
+
+		add_filter( 'themeisle_sdk_plugin_api_filter_registered', '__return_false' );
+
+		$module->load( $plugin_product );
+		$this->assertTrue( (bool) has_filter( 'plugins_api_result', [ $module, 'filter_plugin_api_results' ] ) );
+	}
+
 }

--- a/tests/sample_products/sample_pro_plugin/plugin_file.php
+++ b/tests/sample_products/sample_pro_plugin/plugin_file.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Plugin Name:       Sample plugin.
+ * Plugin Name:       Sample Pro plugin.
  * Description:       Sample description
  * Version:           1.1.1
  * Author:            ThemeIsle
  * Author URI:        https://themeisle.com
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
- * Text Domain:       sample-plugin
+ * Text Domain:       sample-pro-plugin
  * WordPress Available:  no
  * Requires License:    no
  */


### PR DESCRIPTION
### Summary
Prepend plugins to the featured plugins list if the plugin is PRO.
When used inside a pro product will prepend **Optimole** and **Otter Blocks** to the plugin Featured tab.

The following filters are introduced:
```php
// can be used to disable this feature even if the product is PRO.
apply_filters( 'themeisle_sdk_disable_featured_plugins', false )

// used to filter what plugins will be available after the filter.
$optimole_filter_slugs  = apply_filters( 'themeisle_sdk_optimole_filter_slugs', [ 'optimole-wp' ] );
$themeisle_filter_slugs  = apply_filters( 'themeisle_sdk_themeisle_filter_slugs', [ 'otter-blocks' ] );
```

The total number of plugins listed inside the Featured Tab will remain the same, it will push the last x items from the end.

### Screenshots
<details open>
    <summary>Featured products</summary>

![image](https://github.com/Codeinwp/themeisle-sdk/assets/23024731/9c38e64b-5ddb-4aa1-963d-7c2a3df2fd2f)
</details>

### How to test
1. On a fresh instance with this SDK build from a PRO plugin
2. Check that inside **Plugins** > **Add New Plugin** > **Featured** (Optimole and Otter) are listed.

Closes: Codeinwp/marketing#108