### PR TITLE
Fix/filter promotions

### DIFF
--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -34,6 +34,14 @@ class Promotions extends Abstract_Module {
 	private $promotions = array();
 
 	/**
+     * Holds the values of the promotions that are not allowed to be shown.
+     * Can be filtered by each product.
+     *
+	 * @var array
+	 */
+    private $dissallowed_promotions = array();
+
+	/**
 	 * Option key for promos.
 	 *
 	 * @var string
@@ -112,6 +120,8 @@ class Promotions extends Abstract_Module {
 		$promotions_to_load[] = 'neve-fse';
 
 		$this->promotions = $this->get_promotions();
+
+        $this->dissallowed_promotions = apply_filters( $product->get_key() . '_dissallowed_promotions', array() );
 
 		foreach ( $this->promotions as $slug => $data ) {
 			if ( ! in_array( $slug, $promotions_to_load, true ) ) {
@@ -505,6 +515,10 @@ class Promotions extends Abstract_Module {
 
 			$return = array_merge( $return, $this->promotions[ $slug ] );
 		}
+
+        $return = array_filter( $return, function ( $value, $key ) {
+            return ! in_array( $key, $this->dissallowed_promotions, true );
+        }, ARRAY_FILTER_USE_BOTH );
 
 		return array_keys( $return );
 	}

--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -34,12 +34,12 @@ class Promotions extends Abstract_Module {
 	private $promotions = array();
 
 	/**
-     * Holds the values of the promotions that are not allowed to be shown.
-     * Can be filtered by each product.
-     *
+	 * Holds the values of the promotions that are not allowed to be shown.
+	 * Can be filtered by each product.
+	 *
 	 * @var array
 	 */
-    private $dissallowed_promotions = array();
+	private $dissallowed_promotions = array();
 
 	/**
 	 * Option key for promos.
@@ -121,7 +121,7 @@ class Promotions extends Abstract_Module {
 
 		$this->promotions = $this->get_promotions();
 
-        $this->dissallowed_promotions = apply_filters( $product->get_key() . '_dissallowed_promotions', array() );
+		$this->dissallowed_promotions = apply_filters( $product->get_key() . '_dissallowed_promotions', array() );
 
 		foreach ( $this->promotions as $slug => $data ) {
 			if ( ! in_array( $slug, $promotions_to_load, true ) ) {
@@ -516,9 +516,13 @@ class Promotions extends Abstract_Module {
 			$return = array_merge( $return, $this->promotions[ $slug ] );
 		}
 
-        $return = array_filter( $return, function ( $value, $key ) {
-            return ! in_array( $key, $this->dissallowed_promotions, true );
-        }, ARRAY_FILTER_USE_BOTH );
+		$return = array_filter(
+			$return,
+			function ( $value, $key ) {
+				return ! in_array( $key, $this->dissallowed_promotions, true );
+			},
+			ARRAY_FILTER_USE_BOTH 
+		);
 
 		return array_keys( $return );
 	}

--- a/tests/promotion-test.php
+++ b/tests/promotion-test.php
@@ -73,4 +73,75 @@ class Promotion_Test extends WP_UnitTestCase {
 		$option = get_option( $option_key );
 		$this->assertEquals( 'test', $option );
 	}
+
+	/**
+	 * Test the promotion dissallow filter and the promotion loading without it.
+	 *
+	 * @return void
+	 */
+	public function testPromotionDisallowFilter() {
+		wp_set_current_user( 1 );
+		$file    = dirname( __FILE__ ) . '/sample_products/sample_plugin/plugin_file.php';
+		$product = new \ThemeisleSDK\Product( $file );
+
+		$promotions = new \ThemeisleSDK\Modules\Promotions();
+
+		$this->assertTrue( $promotions->can_load( $product ) );
+		$promotions->load( $product );
+
+		set_current_screen( 'edit-post' );
+		$current_screen = get_current_screen();
+		$current_screen->is_block_editor( true );
+
+		$promotions->load_available();
+		$promotions->enqueue();
+
+		global $wp_scripts; // phpcs:ignore
+		$data                     = $wp_scripts->get_data( 'ti-sdk-promo', 'data' );
+		$prev_data                = $data;
+		$data                     = str_replace( 'var themeisleSDKPromotions = ', '', $data );
+		$data                     = substr( $data, 0, -1 );
+		$themeisle_sdk_promotions = json_decode( $data, true );
+
+		$this->assertEquals( 'Sample plugin.', $themeisle_sdk_promotions['product'] );
+		$this->assertTrue( ! empty( $themeisle_sdk_promotions['showPromotion'] ) );
+
+		add_filter(
+			'sample_plugin_dissallowed_promotions',
+			function () {
+				return [
+					'om-editor',
+					'om-image-block',
+					'om-attachment',
+					'om-media',
+					'om-elementor',
+					'blocks-css',
+					'blocks-animation',
+					'blocks-conditions',
+					'rop-posts',
+					'ppom',
+					'sparks-wishlist',
+					'sparks-announcement',
+					'sparks-product-review',
+				];
+			}
+		);
+
+		$promotions = new \ThemeisleSDK\Modules\Promotions();
+
+		$this->assertTrue( $promotions->can_load( $product ) );
+		$promotions->load( $product );
+		$promotions->load_available();
+		$promotions->enqueue();
+
+		global $wp_scripts; // phpcs:ignore
+		$data = $wp_scripts->get_data( 'ti-sdk-promo', 'data' );
+		// we remove the previous enqueued data to only use the new one.
+		$data                     = str_replace( $prev_data, '', $data );
+		$data                     = str_replace( 'var themeisleSDKPromotions = ', '', $data );
+		$data                     = substr( $data, 0, -1 );
+		$themeisle_sdk_promotions = json_decode( $data, true );
+
+		$this->assertTrue( empty( $themeisle_sdk_promotions['showPromotion'] ) ); // This should be empty as we filter all promotions.
+	}
 }


### PR DESCRIPTION
### Summary

I added a new filter to allow products to filter promotions that can be displayed for each product.
Added unit test to test the newly introduced filter.

Closes: Codeinwp/themeisle#1634.