### PR TITLE
fix: script loading when multiple products are loaded

### DIFF
--- a/src/Modules/Script_loader.php
+++ b/src/Modules/Script_loader.php
@@ -31,10 +31,6 @@ class Script_Loader extends Abstract_Module {
 	 * @return bool Should we load ?
 	 */
 	public function can_load( $product ) {
-		if ( apply_filters( 'themeisle_sdk_ran_promos', false ) === true ) {
-			return false;
-		}
-
 		if ( $this->is_from_partner( $product ) ) {
 			return false;
 		}
@@ -56,11 +52,18 @@ class Script_Loader extends Abstract_Module {
 	}
 
 	/**
-	 * Setup actions.
+	 * Setup actions. Once for all products.
 	 */
 	private function setup_actions() {
+
+		if ( apply_filters( 'themeisle_sdk_script_setup', false ) ) {
+			return;
+		}
+
 		add_filter( 'themeisle_sdk_dependency_script_handler', [ $this, 'get_script_handler' ], 10, 1 );
 		add_action( 'themeisle_sdk_dependency_enqueue_script', [ $this, 'enqueue_script' ], 10, 1 );
+
+		add_filter( 'themeisle_sdk_script_setup', '__return_true' );
 	}
 
 	/**

--- a/tests/script-loader-test.php
+++ b/tests/script-loader-test.php
@@ -74,6 +74,35 @@ class Script_Loader_Test extends WP_UnitTestCase {
 		$this->assertEquals( has_action( 'themeisle_sdk_dependency_enqueue_script', [ $module, 'enqueue_script' ] ), 10 );
 	}
 
+	public function test_multiple_script_loading() {
+		$file = dirname( __FILE__ ) . '/sample_products/sample_theme/style.css';
+
+		$product = new \ThemeisleSDK\Product( $file );
+		
+		/**
+		 * When multiple products are loaded, the script loader hooks registration should not be triggered multiple times.
+		 */
+		( new \ThemeisleSDK\Modules\Script_Loader() )->load( $product );
+		( new \ThemeisleSDK\Modules\Script_Loader() )->load( $product );
+		( new \ThemeisleSDK\Modules\Script_Loader() )->load( $product );
+		
+		// Load survey script.
+		$handler = apply_filters( 'themeisle_sdk_dependency_script_handler', 'survey' );
+		$this->assertNotEmpty( $handler );
+		$this->assertTrue( 'themeisle_sdk_survey_script' === $handler );
+		do_action( 'themeisle_sdk_dependency_enqueue_script', 'survey' );
+		$this->assertTrue( wp_script_is( $handler, 'enqueued' ) );
+
+		// Load tracking script.
+		$handler = apply_filters( 'themeisle_sdk_dependency_script_handler', 'tracking' );
+		$this->assertNotEmpty( $handler );
+		$this->assertTrue( 'themeisle_sdk_tracking_script' === $handler );
+		do_action( 'themeisle_sdk_dependency_enqueue_script', 'tracking' );
+		$this->assertTrue( wp_script_is( $handler, 'enqueued' ) );
+
+		$this->assertTrue( has_filter( 'themeisle_sdk_script_setup' ) );
+	}
+
 	public function test_script_loader_handler_check() {
 		$file = dirname( __FILE__ ) . '/sample_products/sample_theme/style.css';
 


### PR DESCRIPTION
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2785

## Summary

- Removed the promo conditions.
- When multiple products are loaded, the script loader will register the hooks only once.
- Added test for multiple product loading case.

## Testing

1. Install the build from this PR.
2. From WP Store, install visualizer, feedzy, mpg.
3. In the Browser Console, check if the `survey_deps.js` is loaded on product dashboards. 