### PR TITLE
fix: rollback for themes WP6.3

### DIFF
--- a/load.php
+++ b/load.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 // Current SDK version and path.
-$themeisle_sdk_version = '3.3.16';
+$themeisle_sdk_version = '3.3.18';
 $themeisle_sdk_path    = dirname( __FILE__ );
 
 global $themeisle_sdk_max_version;

--- a/load.php
+++ b/load.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 // Current SDK version and path.
-$themeisle_sdk_version = '3.3.18';
+$themeisle_sdk_version = '3.3.16';
 $themeisle_sdk_path    = dirname( __FILE__ );
 
 global $themeisle_sdk_max_version;

--- a/src/Modules/Rollback.php
+++ b/src/Modules/Rollback.php
@@ -261,7 +261,7 @@ class Rollback extends Abstract_Module {
 		add_filter( 'update_theme_complete_actions', array( $this, 'alter_links_theme_upgrade' ) );
 		$rollback   = $this->get_rollback();
 		$transient  = get_site_transient( 'update_themes' );
-        $slug       = $this->product->get_slug();
+		$slug       = $this->product->get_slug();
 		$folder     = $slug;
 		$version    = $rollback['version'];
 		$temp_array = array(

--- a/src/Modules/Rollback.php
+++ b/src/Modules/Rollback.php
@@ -261,7 +261,8 @@ class Rollback extends Abstract_Module {
 		add_filter( 'update_theme_complete_actions', array( $this, 'alter_links_theme_upgrade' ) );
 		$rollback   = $this->get_rollback();
 		$transient  = get_site_transient( 'update_themes' );
-		$folder     = $this->product->get_slug();
+        $slug       = $this->product->get_slug();
+		$folder     = $slug;
 		$version    = $rollback['version'];
 		$temp_array = array(
 			'new_version' => $version,
@@ -285,7 +286,7 @@ class Rollback extends Abstract_Module {
 			$url   = 'update.php?action=upgrade-theme&theme=' . urlencode( $theme );
 
 			$upgrader = new \Theme_Upgrader( new \Theme_Upgrader_Skin( compact( 'title', 'nonce', 'url', 'theme' ) ) );
-			$upgrader->upgrade( $theme );
+			$upgrader->upgrade( $slug );
 			delete_transient( $this->product->get_key() . '_warning_rollback' );
 			wp_die(
 				'',


### PR DESCRIPTION
### Summary
After the changes introduced in WP 6.3 https://make.wordpress.org/core/2023/07/11/new-in-6-3-rollback-for-failed-manual-plugin-and-theme-updates/ on Rollback it would try to create a directory inside the `upgrade-temp-backup/themes` but the slug that was passed to the upgrader would be of the format `theme-slug/style.css`.

The Rollback would fail because it could not create the specified folder: `upgrade-temp-backup/themes/theme-slug/style.css`

The rollback will attach a temporary theme for the rollback to the transient.
However, when executing the upgrade for the attached theme we need to change the slug to the original theme slug.
This is because it will use the slug to create a temp folder for the theme used during the upgrade.

We now filter the slug during the upgrade to ensure the targeted theme slug is used.

> [!TIP]
> Checked the plugin rollback, and that works correctly as the slug is passed as expected.


### Tested
Version 6.2.4 is the latest WP version before the changes were introduced to the upgrader.

- [x] Rollback Theme on v6.4.3
- [x] Rollback Theme on v6.2.4
- [x] Rollback Plugin on v6.4.3
- [x] Rollback Plugin on v6.2.4  


Closes: Codeinwp/neve-pro-addon#2791