### PR TITLE
fix: typo in Licenser.php

### DIFF
--- a/src/Modules/Licenser.php
+++ b/src/Modules/Licenser.php
@@ -139,7 +139,7 @@ class Licenser extends Abstract_Module {
 		$value  = $this->license_key;
 
 		$activate_string   = apply_filters( $this->product->get_key() . '_lc_activate_string', Loader::$labels['licenser']['activate'] );
-		$deactivate_string = apply_filters( $this->product->get_key() . '_lc_deactivate_string', Loader::$labels['licenser']['deactivateactivate'] );
+		$deactivate_string = apply_filters( $this->product->get_key() . '_lc_deactivate_string', Loader::$labels['licenser']['deactivate'] );
 		$valid_string      = apply_filters( $this->product->get_key() . '_lc_valid_string', Loader::$labels['licenser']['valid'] );
 		$invalid_string    = apply_filters( $this->product->get_key() . '_lc_invalid_string', Loader::$labels['licenser']['invalid'] );
 		$license_message   = apply_filters( $this->product->get_key() . '_lc_license_message', Loader::$labels['licenser']['notice'] );


### PR DESCRIPTION
Fixes a typo that tries to display a non-existing string.

<img width="826" alt="Screenshot 2024-04-29 at 6 13 07 PM" src="https://github.com/Codeinwp/themeisle-sdk/assets/2649903/49b82d36-b6d1-4f28-a210-7c6d1facfc72">
