### PR TITLE
Activate the logger flag for PRO users

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -37,7 +37,7 @@ final class Loader {
 	/**
 	 * Holds registered products.
 	 *
-	 * @var array The products which use the SDK.
+	 * @var array<Product> The products which use the SDK.
 	 */
 	private static $products = [];
 	/**
@@ -353,7 +353,7 @@ final class Loader {
 	/**
 	 * Get all products using the SDK.
 	 *
-	 * @return array Products available.
+	 * @return array<Product> Products available.
 	 */
 	public static function get_products() {
 		return self::$products;

--- a/src/Modules/Logger.php
+++ b/src/Modules/Logger.php
@@ -188,7 +188,7 @@ class Logger extends Abstract_Module {
 
 	/**
 	 * Load telemetry.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function load_telemetry() {
@@ -198,35 +198,35 @@ class Logger extends Abstract_Module {
 			$all_products                               = Loader::get_products();
 			$all_products[ $this->product->get_slug() ] = $this->product; // Add current product to the list of products to check for telemetry.
 
+			// Register telemetry params for eligible products.
 			foreach ( $all_products as $product_slug => $product ) {
-				
-				// Ignore pro products.
+
+				// Ignore PRO products.
 				if ( false !== strstr( $product_slug, 'pro' ) ) {
 					continue;
 				}
 
-				$default = 'no';
+				$pro_slug   = $product->get_pro_slug();
+				$logger_key = $product->get_key() . '_logger_flag';
 
-				if ( ! $product->is_wordpress_available() ) {
-					$default = 'yes';
-				} else {
-					$pro_slug = $product->get_pro_slug();
+				// If the product is not available in the WordPress store, or it's PRO version is installed, activate the logger if it was not initialized -- Pro users are opted in by default.
+				if ( ! $product->is_wordpress_available() || ( ! empty( $pro_slug ) && isset( $all_products[ $pro_slug ] ) ) ) {
+					$logger_flag = get_option( $logger_key );
 
-					if ( ! empty( $pro_slug ) && isset( $all_products[ $pro_slug ] ) ) {
-						$default = 'yes';
+					if ( false === $logger_flag ) {
+						update_option( $logger_key, 'yes' );
 					}
 				}
 
-				if ( 'yes' === get_option( $product->get_key() . '_logger_flag', $default ) ) {
+				if ( 'yes' === get_option( $product->get_key() . '_logger_flag', 'no' ) ) {
 
 					$main_slug  = explode( '-', $product_slug );
 					$main_slug  = $main_slug[0];
-					$pro_slug   = $product->get_pro_slug();
 					$track_hash = Licenser::create_license_hash( str_replace( '-', '_', ! empty( $pro_slug ) ? $pro_slug : $product_slug ) );
 
 					// Check if product was already tracked.
 					$active_telemetry = false;
-					foreach ( $products_with_telemetry as &$product_with_telemetry ) {
+					foreach ( $products_with_telemetry as $product_with_telemetry ) {
 						if ( $product_with_telemetry['slug'] === $main_slug ) {
 							$active_telemetry = true;
 							break;
@@ -236,7 +236,7 @@ class Logger extends Abstract_Module {
 					if ( $active_telemetry ) {
 						continue;
 					}
-					
+
 					$products_with_telemetry[] = array(
 						'slug'      => $main_slug,
 						'trackHash' => $track_hash ? $track_hash : 'free',
@@ -251,7 +251,6 @@ class Logger extends Abstract_Module {
 				return;
 			}
 
-
 			$tracking_handler = apply_filters( 'themeisle_sdk_dependency_script_handler', 'tracking' );
 			if ( ! empty( $tracking_handler ) ) {
 				do_action( 'themeisle_sdk_dependency_enqueue_script', 'tracking' );
@@ -265,10 +264,6 @@ class Logger extends Abstract_Module {
 				);
 			}
 		} catch ( \Exception $e ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
-				error_log( $e->getMessage() ); // phpcs:ignore
-			}
-		} catch ( \Error $e ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
 				error_log( $e->getMessage() ); // phpcs:ignore
 			}


### PR DESCRIPTION
## Summary

Until now, if the user was PRO, we assumed the default state as `yes,` thus, all PRO users are tracked by default. But this was not reflected in the logger flag option, making the UI state appear false.

If a PRO wanted to stop the tracking, he needed to trigger the toggle twice (once with the value `true` and again to set it to `false`). It's not an ideal situation.

With this update, if that logger flag is not yet set and the user is PRO, we update the option. Thus, it will be picked by the UI in the plugins.

> [!NOTE]
> Not all the products are affected by those changes! *Only the ones that have _Pro Slug_ in [their plugin file](https://github.com/Codeinwp/feedzy-rss-feeds/blob/eced321ba798d4cd7dca5def0388c96d65ec3201/feedzy-rss-feed.php#L26)*

## Testing

1. Use Feedzy
2. Check the tracking checkbox; it should be false by default.
3. Add Feedzy PRO
4. The checkbox should now be checked. 

![image](https://github.com/Codeinwp/themeisle-sdk/assets/17597852/bf408fb8-769e-4b9c-8d61-51666899d9ba)

Closes https://github.com/Codeinwp/feedzy-rss-feeds-pro/issues/717
