### PR TITLE
Feat/affiliate upgrade option

### DIFF
--- a/load.php
+++ b/load.php
@@ -133,11 +133,11 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 
 			$theme_option_url = get_option( $theme_upgrade_option_name, false );
 			if ( ! empty( $theme_option_url ) ) {
-				$utmify_url = esc_url( $theme_option_url );
+				$utmify_url = esc_url_raw( $theme_option_url );
 			}
 			$plugin_option_url = get_option( $plugin_upgrade_option_name, false );
 			if ( ! empty( $plugin_option_url ) ) {
-				$utmify_url = esc_url( $plugin_option_url );
+				$utmify_url = esc_url_raw( $plugin_option_url );
 			}
 		}
 

--- a/load.php
+++ b/load.php
@@ -127,8 +127,8 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 		 * Check if there is an affiliate URL for this upgrade link, if so use it.
 		 */
 		if ( $is_upgrade_url ) {
-			$option_content_key = str_replace( '-', '_', $filter_key );
-			$theme_upgrade_option_name = 'themeisle_af_' . $option_content_key . '_themes_upgrade';
+			$option_content_key         = str_replace( '-', '_', $filter_key );
+			$theme_upgrade_option_name  = 'themeisle_af_' . $option_content_key . '_themes_upgrade';
 			$plugin_upgrade_option_name = 'themeisle_af_' . $option_content_key . '_plugins_upgrade';
 
 			$theme_option_url = get_option( $theme_upgrade_option_name, false );

--- a/load.php
+++ b/load.php
@@ -133,11 +133,11 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 
 			$theme_option_url = get_option( $theme_upgrade_option_name, false );
 			if ( ! empty( $theme_option_url ) ) {
-				$utmify_url = $theme_option_url;
+				$utmify_url = esc_url( $theme_option_url );
 			}
 			$plugin_option_url = get_option( $plugin_upgrade_option_name, false );
 			if ( ! empty( $plugin_option_url ) ) {
-				$utmify_url = $plugin_option_url;
+				$utmify_url = esc_url( $plugin_option_url );
 			}
 		}
 

--- a/load.php
+++ b/load.php
@@ -91,6 +91,7 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 			$current_page = sanitize_key( str_replace( '.php', '', $current_page ) );
 		}
 		$location        = $location === null ? $current_page : $location;
+		$is_upgrade_url  = strpos( $url, '/upgrade' ) !== false;
 		$content         = sanitize_key(
 			trim(
 				str_replace(
@@ -121,6 +122,26 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 				$url
 			)
 		);
+
+		/**
+		 * Check if there is an affiliate URL for this upgrade link, if so use it.
+		 */
+		if ( $is_upgrade_url ) {
+			$option_content_key = str_replace( '-', '_', $filter_key );
+			$theme_upgrade_option_name = 'themeisle_af_' . $option_content_key . '_themes_upgrade';
+			$plugin_upgrade_option_name = 'themeisle_af_' . $option_content_key . '_plugins_upgrade';
+
+			$theme_option_url = get_option( $theme_upgrade_option_name, false );
+			if ( ! empty( $theme_option ) ) {
+				$utmify_url = $theme_option_url;
+			}
+			$plugin_option_url = get_option( $plugin_upgrade_option_name, false );
+			if ( ! empty( $plugin_option_url ) ) {
+				$utmify_url = $plugin_option_url;
+			}
+		}
+
+
 
 		return apply_filters( 'tsdk_utmify_url_' . $filter_key, $utmify_url, $url );
 	}

--- a/load.php
+++ b/load.php
@@ -132,7 +132,7 @@ if ( ! function_exists( 'tsdk_utmify' ) ) {
 			$plugin_upgrade_option_name = 'themeisle_af_' . $option_content_key . '_plugins_upgrade';
 
 			$theme_option_url = get_option( $theme_upgrade_option_name, false );
-			if ( ! empty( $theme_option ) ) {
+			if ( ! empty( $theme_option_url ) ) {
 				$utmify_url = $theme_option_url;
 			}
 			$plugin_option_url = get_option( $plugin_upgrade_option_name, false );

--- a/tests/utmify-test.php
+++ b/tests/utmify-test.php
@@ -21,7 +21,7 @@ class Utmify_Test extends WP_UnitTestCase {
 				return $arguments;
 			},
 			11,
-			2 
+			2
 		);
 	}
 
@@ -33,8 +33,12 @@ class Utmify_Test extends WP_UnitTestCase {
 				return self::AFFILIATE_URL;
 			},
 			11,
-			2 
+			2
 		);
+	}
+
+	private function set_plugin_upgrade_option( $filter_key, $url ) {
+		update_option( 'themeisle_af_' . $filter_key . '_plugins_upgrade', $url );
 	}
 
 
@@ -58,6 +62,12 @@ class Utmify_Test extends WP_UnitTestCase {
 		$this->register_filter_url();
 
 		$link = tsdk_utmify( 'https://example.com/link', 'area', 'location' );
+
+		$this->assertEquals( self::AFFILIATE_URL, $link );
+
+		$this->set_plugin_upgrade_option( 'sample_plugin', self::AFFILIATE_URL );
+
+		$link = tsdk_utmify( 'https://themeisle.com/plugins/sample-plugin/upgrade', 'area', 'location' );
 
 		$this->assertEquals( self::AFFILIATE_URL, $link );
 


### PR DESCRIPTION
### Summary
Will allow upgrade URL to be passed from the db option if present.
This only applies to current upgrade URLs.

### How to test
1. On a fresh instance of Neve
2. Update the option `themeisle_af_neve_themes_upgrade` with the desired affiliate URL (eg. `https://example.com/affiliate/upgrade`).
3. Check that the upgrade URLs are replaced correctly.

Closes: Codeinwp/neve-pro-addon#2801