### PR TITLE
fix: featured available on in some free plugins

### DIFF
--- a/src/Modules/Featured_plugins.php
+++ b/src/Modules/Featured_plugins.php
@@ -33,6 +33,21 @@ class Featured_Plugins extends Abstract_Module {
 	private $transient_key = 'themeisle_sdk_featured_plugins_';
 
 	/**
+	 * Check if the slug contains "pro" word as part of slug.
+	 *
+	 * @param string $slug The product slug.
+	 *
+	 * @return bool
+	 */
+	private function is_pro_slug( $slug ) {
+		if ( ! is_string( $slug ) || empty( $slug ) ) {
+			return false;
+		}
+		// Match "pro" as a whole word exclude '_' from the word boundary.
+		return (bool) preg_match( '/(?:\b|_\K)pro(?=\b|_)/', $slug );
+	}
+
+	/**
 	 * Check if the module can be loaded.
 	 *
 	 * @param Product $product Product data.
@@ -46,7 +61,7 @@ class Featured_Plugins extends Abstract_Module {
 
 		$slug = $product->get_slug();
 		// only load for products that contain "pro" in the slug.
-		if ( strpos( $slug, 'pro' ) === false ) {
+		if ( $this->is_pro_slug( $slug ) === false ) {
 			return false;
 		}
 

--- a/tests/featured-plugins-test.php
+++ b/tests/featured-plugins-test.php
@@ -98,6 +98,23 @@ class Featured_Plugins_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Utility method to change the value of a protected property.
+	 *
+	 * @param mixed  $object The object.
+	 * @param string $property The property name.
+	 * @param mixed  $new_value The new value.
+	 *
+	 * @return void
+	 * @throws ReflectionException Throws an exception if the property does not exist.
+	 */
+	private function set_protected_property( $object, $property, $new_value ) {
+		$reflection = new ReflectionClass( $object );
+		$property   = $reflection->getProperty( $property );
+		$property->setAccessible( true );
+		$property->setValue( $object, $new_value );
+	}
+
+	/**
 	 * Test plugin not loading without config.
 	 */
 	public function test_plugin_not_loading_if_not_pro() {
@@ -115,6 +132,18 @@ class Featured_Plugins_Test extends WP_UnitTestCase {
 		$plugin_product = new \ThemeisleSDK\Product( $plugin );
 
 		$this->assertTrue( ( new \ThemeisleSDK\Modules\Featured_Plugins() )->can_load( $plugin_product ) );
+	}
+
+	/**
+	 * Test plugin not loading for slugs that contain pro as part of a word. Eg. Product.
+	 */
+	public function test_plugin_loading_for_words_w_pro() {
+		$plugin         = dirname( __FILE__ ) . '/sample_products/sample_pro_plugin/plugin_file.php';
+		$plugin_product = new \ThemeisleSDK\Product( $plugin );
+
+		$this->set_protected_property( $plugin_product, 'slug', 'woocommerce-product-addon' );
+
+		$this->assertFalse( ( new \ThemeisleSDK\Modules\Featured_Plugins() )->can_load( $plugin_product ) );
 	}
 
 	/**


### PR DESCRIPTION
### Summary

The featured module was being loaded for slugs that contained `pro` as part of another word eg. `product`.
I changed the check to account for that and introduced a test for this case.

### How to test
1. Using WooCommerce Product Addon and this build of the SDK
2. Check that the Featured products are not visible inside the  Featured Plugins page.
3. All tests should pass.

Closes: Codeinwp/themeisle#1652