### PR TITLE
Removed duplicate feed URL

### DIFF
--- a/src/Modules/Dashboard_widget.php
+++ b/src/Modules/Dashboard_widget.php
@@ -82,7 +82,6 @@ class Dashboard_Widget extends Abstract_Module {
 			'themeisle_sdk_dashboard_widget_feeds',
 			[
 				'https://themeisle.com/blog/feed',
-				'https://www.codeinwp.com/blog/feed',
 				'https://wpshout.com/feed',
 			]
 		);


### PR DESCRIPTION
I've removed the `codeinwp` feed URL because now the `wpshout` feed URL returns the same feed items.

Close https://github.com/Codeinwp/themeisle/issues/1643