### PR TITLE
Removed SDK promos limitations

### DIFF
--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -115,6 +115,7 @@ class Promotions extends Abstract_Module {
 
 		$this->debug          = apply_filters( 'themeisle_sdk_promo_debug', $this->debug );
 		$promotions_to_load   = apply_filters( $product->get_key() . '_load_promotions', array() );
+		$promotions_to_load[] = 'otter';
 		$promotions_to_load[] = 'optimole';
 		$promotions_to_load[] = 'rop';
 		$promotions_to_load[] = 'woo_plugins';


### PR DESCRIPTION
I've added `Otter` to remove the promos limitations.
More details here: https://github.com/Codeinwp/otter-internals/issues/221

Close https://github.com/Codeinwp/otter-internals/issues/221