### PR TITLE
fix: repoint notice-dismiss callback to Notification::dismiss (regular_dismiss does not exist)

### DIFF
--- a/src/Modules/Promotions.php
+++ b/src/Modules/Promotions.php
@@ -209,7 +209,7 @@ class Promotions extends Abstract_Module {
 		add_filter( 'themeisle_sdk_ran_promos', '__return_true' );
 
 		if ( get_option( $this->option_neve, false ) !== true ) {
-			add_action( 'wp_ajax_themeisle_sdk_dismiss_notice', 'ThemeisleSDK\Modules\Notification::regular_dismiss' );
+			add_action( 'wp_ajax_themeisle_sdk_dismiss_notice', 'ThemeisleSDK\Modules\Notification::dismiss' );
 		}
 	}
 


### PR DESCRIPTION
## Problem

`Promotions::load()` registers the notice-dismiss AJAX handler against a method that **does not exist**:

```php
// src/Modules/Promotions.php
if ( get_option( $this->option_neve, false ) !== true ) {
    add_action( 'wp_ajax_themeisle_sdk_dismiss_notice', 'ThemeisleSDK\Modules\Notification::regular_dismiss' );
}
```

`Notification::regular_dismiss` is defined nowhere in the SDK (`git log -S "function regular_dismiss"` is empty across history). The real handler is `Notification::dismiss`, which the SDK already references for this exact action (e.g. the `remove_action( …, [ 'ThemeisleSDK\Modules\Notification', 'dismiss' ] )` in the `neve-themes-popular` branch).

When the broken callback is reached — a user dismissing a **review** notice (`<product_key>_review_flag`) or a promo notice on a **non-Neve** site — WordPress invokes it through `WP_Hook` and PHP fatals:

```
Uncaught TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback,
class ThemeisleSDK\Modules\Notification does not have a method "regular_dismiss"
in wp-includes/class-wp-hook.php:341
```

→ HTTP 500 / blank admin page on dismiss.

## Why it's intermittent (and portfolio-wide)

- The callback is registered by the **Promotions** module for **any** product bundling the SDK — not plugin-specific. Reproduced identically with Otter (`otter_review_flag`) and FreshRank (`freshrank_ai_review_flag`).
- Present in every 3.3.x release checked; introduced long ago and never had a matching method definition.
- **Neve sites are immune** — the `themeisle_sdk_promotions_neve_installed !== true` gate closes, so the bad callback is never registered.
- On non-Neve sites it's latent until the broken callback is actually *reached* (i.e. `Notification::dismiss` doesn't `wp_die()` first), which is why many sites never hit it.

## Fix

One line: point the callback at the existing `Notification::dismiss`. It's idempotent with the registration already done in `Notification::load()` (identical static callback + priority de-duplicates in `WP_Hook`), so sites that were never hitting the bug see no behavioural change; sites that were fataling now dismiss cleanly.

Verified locally against the real `Notification` class by dispatching the hook exactly as `class-wp-hook.php:341` does: with the fix the dismiss succeeds; before it, the verbatim production `TypeError` is raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)